### PR TITLE
Detect HTTP method/verb from routes

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -858,10 +858,16 @@ class FormBuilder {
 	{
 		if (is_array($options))
 		{
+			// if $options is an array, the first argument should be
+			// the route name. This is the same assumption that is made
+			// in getRouteAction()
 			$name = $options[0];
 		}
-
-		$name = $options;
+		else
+		{
+			// otherwise options should be the action name
+			$name = $options;
+		}
 
 		$route = $this->router->getRoutes()->getByName($name);
 
@@ -878,10 +884,15 @@ class FormBuilder {
 	{
 		if (is_array($options))
 		{
+			// if $options is an array, the first argument should be
+			// the action name. This is the same assumption that is made
+			// in getControllerAction()
 			$action = $options[0];
 		}
-
-		$action = $options;
+		else
+		{
+			$action = $options;
+		}
 
 		$route = $this->router->getRoutes()->getByAction($action);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1,7 +1,7 @@
 <?php namespace Collective\Html;
 
 use Carbon\Carbon;
-use Illuminate\Routing\Router;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\Store as Session;
 use Illuminate\Support\Traits\Macroable;
@@ -23,6 +23,13 @@ class FormBuilder {
 	 * @var \Illuminate\Routing\UrlGenerator  $url
 	 */
 	protected $url;
+
+	/**
+	 * The route collection instance.
+	 *
+	 * @var \Illuminate\Routing\RouteCollection
+	 */
+	protected $routes;
 
 	/**
 	 * The CSRF token used by the form builder.
@@ -78,15 +85,15 @@ class FormBuilder {
 	 *
 	 * @param  \Illuminate\Routing\UrlGenerator  $url
 	 * @param  \Collective\Html\HtmlBuilder  $html
-	 * @param  \Illuminate\Routing\Router  $router
+	 * @param  \Illuminate\Routing\RouteCollection  $router
 	 * @param  string  $csrfToken
 	 * @return void
 	 */
-	public function __construct(HtmlBuilder $html, UrlGenerator $url, Router $router, $csrfToken)
+	public function __construct(HtmlBuilder $html, UrlGenerator $url, RouteCollection $routes, $csrfToken)
 	{
 		$this->url = $url;
 		$this->html = $html;
-		$this->router = $router;
+		$this->routes = $routes;
 		$this->csrfToken = $csrfToken;
 	}
 
@@ -902,7 +909,7 @@ class FormBuilder {
 			$name = $options;
 		}
 
-		$route = $this->router->getRoutes()->getByName($name);
+		$route = $this->routes->getByName($name);
 
 		return $route->methods()[0];
 	}
@@ -927,7 +934,7 @@ class FormBuilder {
 			$action = $options;
 		}
 
-		$route = $this->router->getRoutes()->getByAction($action);
+		$route = $this->routes->getByAction($action);
 
 		return $route->methods()[0];
 	}

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -837,11 +837,11 @@ class FormBuilder {
 		// Look up named or controller routes, and get a method for them
 		if (isset($options['route']))
 		{
-			$method = $this->getMethodFromRouteAction($options['route']);
+			$method = $this->getVerbFromRouteAction($options['route']);
 		}
 		elseif (isset($options['action']))
 		{
-			$method = $this->getMethodFromControllerAction($options['action']);
+			$method = $this->getVerbFromControllerAction($options['action']);
 		}
 
 		// Override with explicitly defined method
@@ -854,7 +854,7 @@ class FormBuilder {
 	 * @param  array|string $options
 	 * @return string
 	 */
-	protected function getMethodFromRouteAction($options)
+	protected function getVerbFromRouteAction($options)
 	{
 		if (is_array($options))
 		{
@@ -863,7 +863,7 @@ class FormBuilder {
 
 		$name = $options;
 
-		$route = $this->router->getRoutes()->findByName($name);
+		$route = $this->router->getRoutes()->getByName($name);
 
 		return $route->methods()[0];
 	}
@@ -874,7 +874,7 @@ class FormBuilder {
 	 * @param  array|string $options
 	 * @return string
 	 */
-	protected function getMethodFromControllerAction($options)
+	protected function getVerbFromControllerAction($options)
 	{
 		if (is_array($options))
 		{
@@ -883,7 +883,7 @@ class FormBuilder {
 
 		$action = $options;
 
-		$route = $this->router->getRoutes()->findByAction($action);
+		$route = $this->router->getRoutes()->getByAction($action);
 
 		return $route->methods()[0];
 	}

--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -48,7 +48,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('form', function($app)
 		{
-			$form = new FormBuilder($app['html'], $app['url'], $app['router'], $app['session.store']->getToken());
+			$form = new FormBuilder($app['html'], $app['url'], $app['router']->getRoutes(), $app['session.store']->getToken());
 
 			return $form->setSessionStore($app['session.store']);
 		});

--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -48,7 +48,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('form', function($app)
 		{
-			$form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
+			$form = new FormBuilder($app['html'], $app['url'], $app['router'], $app['session.store']->getToken());
 
 			return $form->setSessionStore($app['session.store']);
 		});

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -17,7 +17,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
   {
     $this->urlGenerator = new UrlGenerator(new RouteCollection, Request::create('/foo', 'GET'));
     $this->htmlBuilder = new HtmlBuilder($this->urlGenerator);
-    $this->formBuilder =  new FormBuilder($this->htmlBuilder, $this->urlGenerator, 'abc');
+    $this->router = m::mock('Illuminate\Routing\Router');
+    $this->formBuilder =  new FormBuilder($this->htmlBuilder, $this->urlGenerator, $this->router, 'abc');
   }
 
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -17,7 +17,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
   {
     $this->urlGenerator = new UrlGenerator(new RouteCollection, Request::create('/foo', 'GET'));
     $this->htmlBuilder = new HtmlBuilder($this->urlGenerator);
-    $this->router = m::mock('Illuminate\Routing\Router');
+    $this->router = m::mock('Illuminate\Routing\RouteCollection');
     $this->formBuilder =  new FormBuilder($this->htmlBuilder, $this->urlGenerator, $this->router, 'abc');
   }
 


### PR DESCRIPTION
The issue: 

Let's say i've got a route definition:

```php
Route::put('users/{user_id}/update', ['as' => 'users.update']);
```

In order to make a form that submits to that route, i have to do:

```php
echo Form::open(['route' => ['users.update', $user->id], 'method' => 'put']);
```

It seems strange having to specify the http method in `Form::open`, when the route definition already has that information. The same is true of controller actions - they both refer to a route definition that has method and url information.

It would be nice to just be able to give the route name:

```php
echo Form::open(['route' => ['users.update', $user->id]]);
```

This is an idea for implementation.

Comments and questions welcome.