### PR TITLE
Extended getSelectedValue to retrieve selected from a model collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "illuminate/http": "~5.0",
     "illuminate/routing": "~5.0",
     "illuminate/session": "~5.0",
-    "illuminate/support": "~5.0"
+    "illuminate/support": "~5.0",
+	"illuminate/database": "~5.0"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -583,6 +583,11 @@ class FormBuilder {
 		{
 			return in_array($value, $selected) ? 'selected' : null;
 		}
+		if($selected instanceof \Illuminate\Database\Eloquent\Collection)
+		{
+			return in_array($value, $selected->modelKeys()) ? 'selected' : null;
+		}
+
 
 		return ((string) $value == (string) $selected) ? 'selected' : null;
 	}

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -7,6 +7,7 @@ use Collective\Html\FormBuilder;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Database\Eloquent\Collection;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
@@ -312,6 +313,18 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
     $this->assertContains('<select id="foo" name="month"><option value="1">January</option>', $month3);
   }
 
+  public function testFormSelectRelatedModle()
+  {
+	  $this->setModel($model = ['languages' => new Collection([
+			new RelatedModelStub(2),
+			new RelatedModelStub(1)
+		])]);
+	  $languages = [1 => 'English', 2 => 'German', 3 => 'French'];
+	  $select = $this->formBuilder->select('languages', $languages, null, ['multiple' => 'multiple']);
+
+	  $this->assertEquals($select, '<select multiple="multiple" name="languages"><option value="1" selected="selected">English</option><option value="2" selected="selected">German</option><option value="3">French</option></select>');
+  }
+
 
   public function testFormCheckbox()
   {
@@ -451,7 +464,6 @@ class FormBuilderModelStub {
     }
   }
 
-
   public function __get($key)
   {
     return $this->data[$key];
@@ -462,4 +474,17 @@ class FormBuilderModelStub {
   {
     return isset($this->data[$key]);
   }
+}
+
+class RelatedModelStub {
+
+	protected $id;
+
+	public function __construct($id) {
+		$this->id = $id;
+	}
+
+	public function getKey() {
+		return $this->id;
+	}
 }


### PR DESCRIPTION
I'm not sure if this is my special requirement or if this is useful for everyone: I'd like to get selected values from a related model. So, e.g. if you have a class ```Product``` which has a many-to-many relationship with  ```Language```, you can do the following:

```php
Form::model($product, ...)
Form:select('languages', )
Form::close()
```