### PR TITLE
Fix for Form::checkbox() default value when used with Form::model()

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -675,6 +675,8 @@ class FormBuilder {
 		if ($this->missingOldAndModel($name)) return $checked;
 
 		$posted = $this->getValueAttribute($name);
+		
+		$posted =  ($posted instanceof \Illuminate\Database\Eloquent\Collection ? $this->checkRelationship($posted, $value) : $posted);
 
 		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
 	}
@@ -944,6 +946,25 @@ class FormBuilder {
 			return array_get($this->model, $this->transformKey($name));
 		}
 	}
+	
+	/**
++	 * Cycle through the Eloquent Collection to see if any
++	 * relationship models include the given input value
++	 *
++	 * @param  \Illuminate\Database\Eloquent\Collection $collection
++	 * @param  string $value
++	 * @param  string $attribute
++	 * @return bool
++	 */
++	protected function checkRelationship($collection, $value, $attribute = 'id')
++	{
++		foreach ($collection as $relation)
++		{
++			if ($relation->$attribute == $value) return true;
++		}
++			
++		return false;
++	}
 
 	/**
 	 * Get a value from the session's old input.

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1,6 +1,7 @@
 <?php namespace Collective\Html;
 
 use DateTime;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\Store as Session;
 use Illuminate\Support\Traits\Macroable;
@@ -676,7 +677,7 @@ class FormBuilder {
 
 		$posted = $this->getValueAttribute($name);
 		
-		$posted =  ($posted instanceof \Illuminate\Database\Eloquent\Collection ? $this->checkRelationship($posted, $value) : $posted);
+		$posted =  $posted instanceof Collection ? $this->checkRelationship($posted, $value) : $posted;
 
 		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
 	}
@@ -956,7 +957,7 @@ class FormBuilder {
 	 * @param  string $attribute
 	 * @return bool
 	 */
-	protected function checkRelationship($collection, $value, $attribute = 'id')
+	protected function checkRelationship(Collection $collection, $value, $attribute = 'id')
 	{
 		foreach ($collection as $relation)
 		{

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -948,23 +948,23 @@ class FormBuilder {
 	}
 	
 	/**
-+	 * Cycle through the Eloquent Collection to see if any
-+	 * relationship models include the given input value
-+	 *
-+	 * @param  \Illuminate\Database\Eloquent\Collection $collection
-+	 * @param  string $value
-+	 * @param  string $attribute
-+	 * @return bool
-+	 */
-+	protected function checkRelationship($collection, $value, $attribute = 'id')
-+	{
-+		foreach ($collection as $relation)
-+		{
-+			if ($relation->$attribute == $value) return true;
-+		}
-+			
-+		return false;
-+	}
+	 * Cycle through the Eloquent Collection to see if any
+	 * relationship models include the given input value
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Collection $collection
+	 * @param  string $value
+	 * @param  string $attribute
+	 * @return bool
+	 */
+	protected function checkRelationship($collection, $value, $attribute = 'id')
+	{
+		foreach ($collection as $relation)
+		{
+			if ($relation->$attribute == $value) return true;
+		}
+			
+		return false;
+	}
 
 	/**
 	 * Get a value from the session's old input.


### PR DESCRIPTION
Currently, when using Form::model(), attempting to manage relationships with Form::checkbox() will result in the checkbox always being checked, no matter if the relationship exists or not. Assuming a one-to-many or many-to-many relationship, something akin to the following will show the checkboxes as checked:

```php
echo Form::model($user);
echo Form::checkbox('permissions[]', '1');
echo Form::checkbox('permissions[]', '2');
echo Form::checkbox('permissions[]', '3');
...
echo Form::close();
```