### PR TITLE
Add aliases to provides()

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -61,7 +61,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('html', 'form');
+		return array('html', 'form', 'Collective\Html\HtmlBuilder', 'Collective\Html\FormBuilder');
 	}
 
 }


### PR DESCRIPTION
The ServiceProvider is deferred, thus only runs when something listed in `provides()` is requested. But when you use dependancy injection, the alias is used.

This adds those aliases. Fixes problems with TwigBridge (https://github.com/rcrowe/TwigBridge/issues/194, https://github.com/rcrowe/TwigBridge/issues/150, https://github.com/rcrowe/TwigBridge/issues/156, https://github.com/rcrowe/TwigBridge/pull/184)

(If you test, remember that `php artisan clear-compiled` is needed before changes are reflected in the app)