### PR TITLE
2 forms replaces eachothers values after validation error

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -233,7 +233,7 @@ class FormBuilder {
 		// in the model instance if one is set. Otherwise we will just use empty.
 		$id = $this->getIdAttribute($name, $options);
 
-		if ( ! in_array($type, $this->skipValueTypes))
+		if ( ! in_array($type, $this->skipValueTypes) && $name !== '_method')
 		{
 			$value = $this->getValueAttribute($name, $value);
 		}


### PR DESCRIPTION
Working on my first Laravel project here and have an issue with how multiple forms on the same page work, triggering validation on form X will repopulate form Y with form X's input _method value.

Bit more details:
Triggering validation on an edit form will repopulate my delete form's input _method value to PATCH on line 887 as both forms share the same input name "_method", this is a specific fix for _method input field as people often use delete form on the same page as edit, but it's part of a larger problem where all input fields with the same name across multiple forms gets replaced by the first form's value.

A better fix would maybe be to set a form ID and save/repopulate them with the ID as a key instead of this "_old_input" key in the Illuminate session component (Store.php) but that's too big a change for me with my limited knowledge on Laravel.