### PR TITLE
FIX on FromBuilder.php

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -676,7 +676,14 @@ class FormBuilder {
 
 		$posted = $this->getValueAttribute($name);
 
-		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
+		
+        	if (is_array($posted)) {
+            		return in_array($value, $posted);
+        	} else if ($posted instanceof \Illuminate\Database\Eloquent\Collection) {
+            		return $posted->contains('id', $value);
+        	} else {
+            		return (bool) $posted;
+        	}
 	}
 
 	/**


### PR DESCRIPTION
HOW TO REPRODUCE BUG:
I have an m:m relation in my isolated form.
This relation si rendered by a list of checkboxes.
Checkboxes names are in the form form_name[relation_name][]

BUG:
Form checkboxes autofill functionalities works well only when:
1. On new form (method=get)
2. On posting some errors

ERROR:
On edit form data the autofill functionalities wont' work because $posted is a Collection, so my edit.