### PR TITLE
Checkboxes work with relationships

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -4,6 +4,7 @@ use DateTime;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\Store as Session;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Collection;
 
 class FormBuilder {
 
@@ -674,16 +675,20 @@ class FormBuilder {
 
 		if ($this->missingOldAndModel($name)) return $checked;
 
-		$posted = $this->getValueAttribute($name);
+		$posted = $this->getValueAttribute($name, $checked);
 
-		
-        	if (is_array($posted)) {
-            		return in_array($value, $posted);
-        	} else if ($posted instanceof \Illuminate\Database\Eloquent\Collection) {
-            		return $posted->contains('id', $value);
-        	} else {
-            		return (bool) $posted;
-        	}
+		if (is_array($posted))
+		{
+			return in_array($value, $posted);
+		}
+		else if ($posted instanceof Collection)
+		{
+			return $posted->contains('id', $value);
+		}
+		else
+		{
+			return (bool) $posted;
+		}
 	}
 
 	/**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -676,7 +676,14 @@ class FormBuilder {
 
 		$posted = $this->getValueAttribute($name);
 
-		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
+		
+        	if (is_array($posted)) {
+            		return in_array($value, $posted);
+        	} else if ($posted instanceof \Illuminate\Database\Eloquent\Collection) {
+            		return $posted->contains('id', $value);
+        	} else {
+            		return (bool) $posted;
+        	}
 	}
 
 	/**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -7,6 +7,7 @@ use Collective\Html\FormBuilder;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Collection;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
@@ -365,6 +366,30 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="1">', $check1);
     $this->assertEquals('<input name="multicheck[]" type="checkbox" value="2">', $check2);
     $this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
+  }
+
+
+  public function testFormCheckboxWithModelRelation()
+  {
+    $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+    $session->shouldReceive('getOldInput')->withNoArgs()->andReturn(array());
+    $session->shouldReceive('getOldInput')->with('items')->andReturn(null);
+
+    $mockModel2 = new StdClass;
+    $mockModel2->id = 2;
+    $mockModel3 = new StdClass;
+    $mockModel3->id = 3;
+    $this->setModel(array('items' => new Collection(array($mockModel2, $mockModel3))));
+
+    $check1 = $this->formBuilder->checkbox('items[]', 1);
+    $check2 = $this->formBuilder->checkbox('items[]', 2);
+    $check3 = $this->formBuilder->checkbox('items[]', 3, false);
+    $check4 = $this->formBuilder->checkbox('items[]', 4, true);
+
+    $this->assertEquals('<input name="items[]" type="checkbox" value="1">', $check1);
+    $this->assertEquals('<input checked="checked" name="items[]" type="checkbox" value="2">', $check2);
+    $this->assertEquals('<input name="items[]" type="checkbox" value="3">', $check3);
+    $this->assertEquals('<input checked="checked" name="items[]" type="checkbox" value="4">', $check4);
   }
 
 


### PR DESCRIPTION
This an important missing feature in this package. There were several pull requests these weeks : #18 and #40. I think that the first one is not in compliance with the *fluent* Laravel style. The second one is close to a good solution but it miss unit testing and a proper code formatting.

For the anecdote, I have made a similar pull request (https://github.com/laravel/framework/pull/3021) long time ago that was merged in the 4.0 branch but lost in master !

I have kept the work of @pazzoone except for this things :

- I removed the dependency to `Illuminate\Database\Eloquent\Collection`, because it is not a dependency of this package.
- I passed the second parameter to the `getValueAttribute` method in order to to be able to set a custom default value.

And, of course, I added a unit test and properly formatted the code.