### PR TITLE
Allow collection as selected parameter for dropdowns

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -437,6 +437,11 @@ class FormBuilder {
 		// so we will use that when checking the model or session for a value which
 		// should provide a convenient method of re-populating the forms on post.
 		$selected = $this->getValueAttribute($name, $selected);
+		// Transform to array if it is a collection
+        if ($selected instanceof Collection)
+        {
+            $selected = $selected->all();
+        }
 
 		$options['id'] = $this->getIdAttribute($name, $options);
 


### PR DESCRIPTION
If you have a dropdown which allows to select multiple options then you can also pass multiple defaults:

```
{!! Form::select('roles', $roleArray, $user->roles->lists('id'), [ 'id' => 'roles', 'multiple' => 'multiple', 'name' => 'roles[]' ]); !!}
```

Problem is that `$user->roles->lists('id')` returns a collection. I could add `->all()` to get an array but it would be nice to do this automatically in LaravelCollective/html.

This pull request adds a simple conversion if `$selected` of the `select()` method is a collection.
