### PR TITLE
add un escape feature for html link function

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -123,15 +123,16 @@ class HtmlBuilder {
 	 * @param  string  $title
 	 * @param  array   $attributes
 	 * @param  bool    $secure
+	 * @param  bool    $escape
 	 * @return string
 	 */
-	public function link($url, $title = null, $attributes = array(), $secure = null)
+	public function link($url, $title = null, $attributes = array(), $secure = null, $escape = true)
 	{
 		$url = $this->url->to($url, array(), $secure);
 
 		if (is_null($title) || $title === false) $title = $url;
 
-		return '<a href="'.$url.'"'.$this->attributes($attributes).'>'.$this->entities($title).'</a>';
+		return '<a href="'.$url.'"'.$this->attributes($attributes).'>'.($escape?$this->entities($title):$title).'</a>';
 	}
 
 	/**


### PR DESCRIPTION
When we use Html::link method link title always gets escaped. But in some cases we might needed not to escape. So added a default variable which is by default true but if I set it to false it will not escape the title of Html::link method.