### PR TITLE
Fix incorrect param type in HtmlBuilder codeblock

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -96,7 +96,7 @@ class HtmlBuilder {
 
 		return '<img src="'.$this->url->asset($url, $secure).'"'.$this->attributes($attributes).'>';
 	}
-	
+
 	/**
 	 * Generate a link to a Favicon file.
 	 *
@@ -313,7 +313,7 @@ class HtmlBuilder {
 	 *
 	 * @param  mixed    $key
 	 * @param  string  $type
-	 * @param  string  $value
+	 * @param  mixed   $value
 	 * @return string
 	 */
 	protected function listingElement($key, $type, $value)
@@ -333,7 +333,7 @@ class HtmlBuilder {
 	 *
 	 * @param  mixed    $key
 	 * @param  string  $type
-	 * @param  string  $value
+	 * @param  mixed   $value
 	 * @return string
 	 */
 	protected function nestedListing($key, $type, $value)


### PR DESCRIPTION
Methods listingElement and nestedListing are documented as receiving a string as third parameters ($value).

However :
1) first instruction in listingElement method is testing if $value is an array
2) if $value is an array, listingElement calls nestedListing element with $value as third parameter (which then is an array).

I have choosed to change the parameter type in docbloc for both methods from string to mixed as $value can also be integer, float, object with __toString method...

Issue in scrutinizer : https://scrutinizer-ci.com/g/simondubois/budget/issues/master/files/app/Services/Html/HtmlBuilder.php?orderField=path&order=asc