### PR TITLE
Don't double escape in Form::option()

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -624,7 +624,7 @@ class FormBuilder {
   {
     $selected = $this->getSelectedValue($value, $selected);
 
-    $options = ['value' => e($value), 'selected' => $selected];
+    $options = ['value' => $value, 'selected' => $selected];
 
     return '<option' . $this->html->attributes($options) . '>' . e($display) . '</option>';
   }


### PR DESCRIPTION
`html->attributes()` already does the escaping.
Let us not depend on the double escaping protection mechanism of `htmlentities()`.

This PR is a copy of https://github.com/illuminate/html/pull/18.