### PR TITLE
Remove dead code in HtmlBuilderTest

### DIFF
--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -4,7 +4,6 @@ use Collective\Html\HtmlBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\UrlGenerator;
-use Mockery as m;
 
 class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 {
@@ -15,14 +14,6 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
     {
         $this->urlGenerator = new UrlGenerator(new RouteCollection(), Request::create('/foo', 'GET'));
         $this->htmlBuilder = new HtmlBuilder($this->urlGenerator);
-    }
-
-    /**
-     * Destroy the test environment.
-     */
-    public function tearDown()
-    {
-        m::close();
     }
 
     public function testDl()


### PR DESCRIPTION
Mockery is not used in HtmlBuilderTest, use statement and tear down should be removed.