### PR TITLE
Replace bindShared with singleton

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -35,7 +35,7 @@ class HtmlServiceProvider extends ServiceProvider
      */
     protected function registerHtmlBuilder()
     {
-        $this->app->bindShared('html', function ($app) {
+        $this->app->singleton('html', function ($app) {
             return new HtmlBuilder($app['url']);
         });
     }
@@ -47,7 +47,7 @@ class HtmlServiceProvider extends ServiceProvider
      */
     protected function registerFormBuilder()
     {
-        $this->app->bindShared('form', function ($app) {
+        $this->app->singleton('form', function ($app) {
             $form = new FormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
 
             return $form->setSessionStore($app['session.store']);


### PR DESCRIPTION
`bindShared()` will be deprecated in laravel 5.2 in favour of `singleton()`

http://laravel.com/docs/5.1/upgrade#upgrade-5.1.0 under Deprecations