### PR TITLE
HtmlBuilder shouldn't depend on concrete implementation

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Collective\Html;
 
-use Illuminate\Routing\UrlGenerator;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\Traits\Macroable;
 
 class HtmlBuilder
@@ -12,14 +12,14 @@ class HtmlBuilder
     /**
      * The URL generator instance.
      *
-     * @var \Illuminate\Routing\UrlGenerator
+     * @var \Illuminate\Contracts\Routing\UrlGenerator
      */
     protected $url;
 
     /**
      * Create a new HTML builder instance.
      *
-     * @param \Illuminate\Routing\UrlGenerator $url
+     * @param \Illuminate\Contracts\Routing\UrlGenerator $url
      *
      * @return void
      */


### PR DESCRIPTION
HtmlBuilder is now coupled to the concrete UrlGenerator which makes it impossible to swap out Laravel's routing component. 
By depending on the interface (contract) this issue will be fixed.