### PR TITLE
Update FormBuilder.php: fix to get selected value with 0 as index

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -694,7 +694,7 @@ class FormBuilder
   protected function getSelectedValue($value, $selected)
   {
       if (is_array($selected)) {
-          return in_array($value, $selected) ? 'selected' : null;
+          return in_array($value, $selected, true) ? 'selected' : null;
       }
 
       return ((string) $value == (string) $selected) ? 'selected' : null;


### PR DESCRIPTION
`getSelectedValue` returns always true if it receives a value (from an select input) of 0. To avoid that the strict parameter has to be set to true.

This is because the following code does not work as might expected:

```
<?php
// check if 0 is in the array [1 => "c16"]
var_dump(in_array(0, [1=>"c16"])); // returns true
```

Setting the strict parameter to true allows to include options with a value of 0 (zero).
