### PR TITLE
Allow select options to have attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 sudo: false
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -620,7 +620,7 @@ class FormBuilder
    */
   public function getSelectOption($display, $value, $selected)
   {
-      if (is_array($display)) {
+      if (is_array($display) && !$this->hasOptionAttributes($display)) {
           return $this->optionGroup($display, $value, $selected);
       }
 
@@ -659,8 +659,13 @@ class FormBuilder
   protected function option($display, $value, $selected)
   {
       $selected = $this->getSelectedValue($value, $selected);
+      $options = [];
 
-      $options = ['value' => $value, 'selected' => $selected];
+      if (is_array($display)) {
+          list($display, $options) = $display;
+      }
+
+      $options = $options + ['value' => $value, 'selected' => $selected];
 
       return '<option'.$this->html->attributes($options).'>'.e($display).'</option>';
   }
@@ -1150,4 +1155,17 @@ class FormBuilder
 
       return $this;
   }
+
+    /**
+     * @param array $display
+     *
+     * @return bool
+     */
+    private function hasOptionAttributes(array $display)
+    {
+        return (
+            array_key_exists(1, $display) &&
+            is_array($display[1])
+        );
+    }
 }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -288,6 +288,60 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             $select,
             '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option></optgroup><option value="S">Small</option></select>'
         );
+
+        $select = $this->formBuilder->select(
+            'size',
+            [
+                'Large sizes' => [
+                    'L' => [
+                        'Large',
+                        [
+                            'disabled',
+                        ],
+                    ],
+                    'XL' => 'Extra Large',
+                ],
+                'S' => 'Small',
+            ],
+            null,
+            [
+                'class' => 'class-name',
+                'id' => 'select-id',
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option disabled="disabled" value="L">Large</option><option value="XL">Extra Large</option></optgroup><option value="S">Small</option></select>'
+        );
+
+        $select = $this->formBuilder->select(
+            'size',
+            [
+                'L' => [
+                    'Large',
+                    [
+                        'disabled' => 'disabled',
+                    ],
+                ],
+                'S' => [
+                    'Small',
+                    [
+                        'disabled',
+                    ],
+                ],
+            ],
+            null,
+            [
+                'class' => 'class-name',
+                'id' => 'select-id',
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select class="class-name" id="select-id" name="size"><option disabled="disabled" value="L">Large</option><option disabled="disabled" value="S">Small</option></select>'
+        );
     }
 
     public function testFormSelectRepopulation()


### PR DESCRIPTION
We have a need to be able to create select boxes that have some `options` disabled. Currently this isn't possible.

I've changed the checking for `options` that contain an array and check to see if the first offset is set (i.e. `$display[1]` is set) and if that offset is an array. If it is then it assumes that we're not dealing with a `optgroup` but instead an array of attributes for the `option`.

``` php
$options = [
    'Large sizes' => [
        'L' => 'Large',
        'XL' => 'Extra Large',
    ],
];

$options = [
    'L' => [
        'Large',
        [
            'disabled' => 'disabled',
        ],
    ],
];
```

In the 2 snippets above, the original syntax will still create an `optgroup` like it currently does, however, the second example will create just a single `option` item with the extra attribute `disabled` added to it.
