### PR TITLE
Fixed fatal error when model not binded

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1103,6 +1103,10 @@ class FormBuilder
      */
     protected function getModelValueAttribute($name)
     {
+        if (!isset($this->model)) {
+            return null;
+        }
+        
         if (method_exists($this->model, 'getFormValue')) {
             return $this->model->getFormValue($name);
         }


### PR DESCRIPTION
Avoid "Fatal error: Call to a member function toArray() on null" when $this->model is not isset.