### PR TITLE
Fixed date fields format bug in model form repopulation.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -90,6 +90,13 @@ class FormBuilder
     protected $skipValueTypes = ['file', 'password', 'checkbox', 'radio'];
 
     /**
+     * The types of inputs to reformat values on.
+     *
+     * @var array
+     */
+    protected $reformatValueTypes = ['date', 'datetime', 'datetime-local'];
+
+    /**
      * Create a new form builder instance.
      *
      * @param  \Collective\Html\HtmlBuilder               $html
@@ -260,6 +267,10 @@ class FormBuilder
 
         if (! in_array($type, $this->skipValueTypes)) {
             $value = $this->getValueAttribute($name, $value);
+
+            if (in_array($type, $this->reformatValueTypes)) {
+                $value = $this->{'format' . camel_case($type)}($value);
+            }
         }
 
         // Once we have the type, value, and ID we can merge them into the rest of the
@@ -356,6 +367,51 @@ class FormBuilder
     }
 
     /**
+     * Format a date input field value.
+     *
+     * @param  string $value
+     * @param  string $format
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDate($value, $format = 'Y-m-d')
+    {
+        if (! is_null($value) && ! ($value instanceof DateTime)) {
+            $value = new DateTime($value);
+        }
+
+        if ($value instanceof DateTime) {
+            $value = $value->format($format);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format a datetime input field value.
+     *
+     * @param  string $value
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDatetime($value)
+    {
+        return $this->formatDate($value, DateTime::RFC3339);
+    }
+
+    /**
+     * Format a datetime-local input field value.
+     *
+     * @param  string $value
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDatetimeLocal($value)
+    {
+        return $this->formatDate($value, 'Y-m-d\TH:i');
+    }
+
+    /**
      * Create a date input field.
      *
      * @param  string $name
@@ -366,9 +422,7 @@ class FormBuilder
      */
     public function date($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format('Y-m-d');
-        }
+        $value = $this->formatDate($value);
 
         return $this->input('date', $name, $value, $options);
     }
@@ -384,9 +438,7 @@ class FormBuilder
      */
     public function datetime($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format(DateTime::RFC3339);
-        }
+        $value = $this->formatDatetime($value);
 
         return $this->input('datetime', $name, $value, $options);
     }
@@ -402,9 +454,7 @@ class FormBuilder
      */
     public function datetimeLocal($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format('Y-m-d\TH:i');
-        }
+        $value = $this->formatDatetimeLocal($value);
 
         return $this->input('datetime-local', $name, $value, $options);
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -202,12 +202,115 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $form2 = $this->formBuilder->date('foo', '2015-02-20');
         $form3 = $this->formBuilder->date('foo', \Carbon\Carbon::now());
         $form4 = $this->formBuilder->date('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->date('foo', '2015-02-20 23:16:58');
 
         $this->assertEquals('<input name="foo" type="date">', $form1);
         $this->assertEquals('<input name="foo" type="date" value="2015-02-20">', $form2);
         $this->assertEquals('<input name="foo" type="date" value="' . \Carbon\Carbon::now()->format('Y-m-d') . '">',
           $form3);
         $this->assertEquals('<input class="span2" name="foo" type="date">', $form4);
+        $this->assertEquals('<input name="foo" type="date" value="2015-02-20">', $form5);
+    }
+
+    public function testFormDateRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->date('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="date" value="2015-02-20">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->date('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="date" value="2015-02-20">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->date('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="date" value="' . \Carbon\Carbon::now()->format('Y-m-d') . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->date('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
+    }
+
+    public function testFormDatetime()
+    {
+        $form1 = $this->formBuilder->datetime('foo');
+        $form2 = $this->formBuilder->datetime('foo', '2015-02-20');
+        $form3 = $this->formBuilder->datetime('foo', \Carbon\Carbon::now());
+        $form4 = $this->formBuilder->datetime('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->datetime('foo', '2015-02-20 23:16:58');
+
+        $this->assertEquals('<input name="foo" type="datetime">', $form1);
+        $this->assertEquals('<input name="foo" type="datetime" value="2015-02-20T00:00:00+00:00">', $form2);
+        $this->assertEquals('<input name="foo" type="datetime" value="' . \Carbon\Carbon::now()->format(DateTime::RFC3339) . '">',
+            $form3);
+        $this->assertEquals('<input class="span2" name="foo" type="datetime">', $form4);
+        $this->assertEquals('<input name="foo" type="datetime" value="2015-02-20T23:16:58+00:00">', $form5);
+    }
+
+    public function testFormDatetimeRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->datetime('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="datetime" value="2015-02-20T00:00:00+00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->datetime('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="datetime" value="2015-02-20T00:00:00+00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->datetime('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="datetime" value="' . \Carbon\Carbon::now()->format(DateTime::RFC3339) . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->datetime('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
+    }
+
+    public function testFormDatetimeLocal()
+    {
+        $form1 = $this->formBuilder->datetimeLocal('foo');
+        $form2 = $this->formBuilder->datetimeLocal('foo', '2015-02-20');
+        $form3 = $this->formBuilder->datetimeLocal('foo', \Carbon\Carbon::now());
+        $form4 = $this->formBuilder->datetimeLocal('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->datetimeLocal('foo', '2015-02-20 23:16:58');
+
+        $this->assertEquals('<input name="foo" type="datetime-local">', $form1);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="2015-02-20T00:00">', $form2);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="' . \Carbon\Carbon::now()->format('Y-m-d\TH:i') . '">',
+            $form3);
+        $this->assertEquals('<input class="span2" name="foo" type="datetime-local">', $form4);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="2015-02-20T23:16">', $form5);
+    }
+
+    public function testFormDatetimeLocalRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->datetimeLocal('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="datetime-local" value="2015-02-20T00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->datetimeLocal('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="datetime-local" value="2015-02-20T00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->datetimeLocal('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="datetime-local" value="' . \Carbon\Carbon::now()->format('Y-m-d\TH:i') . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->datetimeLocal('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
     }
 
     public function testFormTime()


### PR DESCRIPTION
**Scenario:** when binding a form to a model and loading the form by passing an instance of that model to it, date fields values are not correctly formatted.

**Replication Steps:**
* Given a Model with a date attribute and a form model bound to it
* Load the form view passing it an instance of the model with a valid date (ensure such date is loaded in the model as an instance of the Carbon class)
* The date field `value` attribute gets populated with the format `'Y-m-d H:i:s'` which causes the control to not recognise the value

**Solution:**
* Add a `protected reformatValueTypes` property to the `FormBuilder` class, holding an array of the field types to be reformatted if retrieved from a model instance:
  * `date`
  * `datetime`
  * `datetime-local`
* Refactor the `FormBuilder::date()`, `FormBuilder::datetime()`, and `FormBuilder::datetimeLocal()` functions by extrapolating the formatting part to three separate functions which name is built as `{'format' . camel_case($type)}`:
  * `protected function formatDate($value, $format = 'Y-m-d');`
  * `protected function formatDatetime($value);`
  * `protected function formatDatetimeLocal($value);`
* Ensure that the `FormBuilder::input()` function sends the value through the relative format function after retrieving it from either the `old()` flash data or the model instance.

**Effects:** as the included PHPUnit tests show, date fields values are now correctly formatted according to the selected field type.