### PR TITLE
Use array_get's third parameter for default value.

### DIFF
--- a/src/Componentable.php
+++ b/src/Componentable.php
@@ -81,7 +81,7 @@ trait Componentable
                 $default = null;
             }
 
-            $data[$variable] = array_get($arguments, $i) ?: $default;
+            $data[$variable] = array_get($arguments, $i, $default);
 
             $i++;
         }


### PR DESCRIPTION
This allows for using boolean values as default options for components.