### PR TITLE
Avoid using session to build form

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1080,7 +1080,7 @@ class FormBuilder
             return $value;
         }
 
-        if (! is_null($this->old($name))) {
+        if (! is_null($this->old($name)) && $name != '_method') {
             return $this->old($name);
         }
 


### PR DESCRIPTION
As said in #149:

If two forms are loaded with different methods, they load fine the first time.

If the page is redirected back, the second form will load the first form _method, which is a problem.

This commit changes this to not load old attribute if the object is "_method".