### PR TITLE
Accept attribute disabled false

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -426,6 +426,12 @@ class HtmlBuilder
         if (is_numeric($key)) {
             $key = $value;
         }
+        
+        // Browsers disable the field independent of value disabled attribute,
+        // therefore removed the disabled attribute if it is false
+        if ($key == 'disabled' and $value == false) {
+            return null;
+        }
 
         if (! is_null($value)) {
             return $key . '="' . e($value) . '"';


### PR DESCRIPTION
In most browsers, disabled="false" converts to only disabled, thus disabling the field (which is not the desired result).
This makes it difficult to pass this attribute to false, which is required in some applications.