### PR TITLE
Fixed date field format bug on model form repopulation.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -90,6 +90,13 @@ class FormBuilder
     protected $skipValueTypes = ['file', 'password', 'checkbox', 'radio'];
 
     /**
+     * The types of inputs to reformat values on.
+     *
+     * @var array
+     */
+    protected $reformatValueTypes = ['date', 'datetime', 'datetime-local'];
+
+    /**
      * Create a new form builder instance.
      *
      * @param  \Collective\Html\HtmlBuilder               $html
@@ -260,6 +267,10 @@ class FormBuilder
 
         if (! in_array($type, $this->skipValueTypes)) {
             $value = $this->getValueAttribute($name, $value);
+
+            if (in_array($type, $this->reformatValueTypes)) {
+                $value = $this->{'format' . camel_case($type)}($value);
+            }
         }
 
         // Once we have the type, value, and ID we can merge them into the rest of the
@@ -356,6 +367,51 @@ class FormBuilder
     }
 
     /**
+     * Format a date input field value.
+     *
+     * @param  string $value
+     * @param  string $format
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDate($value, $format = 'Y-m-d')
+    {
+        if (! is_null($value) && ! ($value instanceof DateTime)) {
+            $value = new DateTime($value);
+        }
+
+        if ($value instanceof DateTime) {
+            $value = $value->format($format);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format a datetime input field value.
+     *
+     * @param  string $value
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDatetime($value)
+    {
+        return $this->formatDate($value, DateTime::RFC3339);
+    }
+
+    /**
+     * Format a datetime-local input field value.
+     *
+     * @param  string $value
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function formatDatetimeLocal($value)
+    {
+        return $this->formatDate($value, 'Y-m-d\TH:i');
+    }
+
+    /**
      * Create a date input field.
      *
      * @param  string $name
@@ -366,9 +422,7 @@ class FormBuilder
      */
     public function date($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format('Y-m-d');
-        }
+        $value = $this->formatDate($value);
 
         return $this->input('date', $name, $value, $options);
     }
@@ -384,9 +438,7 @@ class FormBuilder
      */
     public function datetime($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format(DateTime::RFC3339);
-        }
+        $value = $this->formatDatetime($value);
 
         return $this->input('datetime', $name, $value, $options);
     }
@@ -402,9 +454,7 @@ class FormBuilder
      */
     public function datetimeLocal($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
-            $value = $value->format('Y-m-d\TH:i');
-        }
+        $value = $this->formatDatetimeLocal($value);
 
         return $this->input('datetime-local', $name, $value, $options);
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -202,12 +202,115 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $form2 = $this->formBuilder->date('foo', '2015-02-20');
         $form3 = $this->formBuilder->date('foo', \Carbon\Carbon::now());
         $form4 = $this->formBuilder->date('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->date('foo', '2015-02-20 23:16:58');
 
         $this->assertEquals('<input name="foo" type="date">', $form1);
         $this->assertEquals('<input name="foo" type="date" value="2015-02-20">', $form2);
         $this->assertEquals('<input name="foo" type="date" value="' . \Carbon\Carbon::now()->format('Y-m-d') . '">',
           $form3);
         $this->assertEquals('<input class="span2" name="foo" type="date">', $form4);
+        $this->assertEquals('<input name="foo" type="date" value="2015-02-20">', $form5);
+    }
+
+    public function testFormDateRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->date('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="date" value="2015-02-20">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->date('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="date" value="2015-02-20">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->date('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="date" value="' . \Carbon\Carbon::now()->format('Y-m-d') . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->date('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
+    }
+
+    public function testFormDatetime()
+    {
+        $form1 = $this->formBuilder->datetime('foo');
+        $form2 = $this->formBuilder->datetime('foo', '2015-02-20');
+        $form3 = $this->formBuilder->datetime('foo', \Carbon\Carbon::now());
+        $form4 = $this->formBuilder->datetime('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->datetime('foo', '2015-02-20 23:16:58');
+
+        $this->assertEquals('<input name="foo" type="datetime">', $form1);
+        $this->assertEquals('<input name="foo" type="datetime" value="2015-02-20T00:00:00+00:00">', $form2);
+        $this->assertEquals('<input name="foo" type="datetime" value="' . \Carbon\Carbon::now()->format(DateTime::RFC3339) . '">',
+            $form3);
+        $this->assertEquals('<input class="span2" name="foo" type="datetime">', $form4);
+        $this->assertEquals('<input name="foo" type="datetime" value="2015-02-20T23:16:58+00:00">', $form5);
+    }
+
+    public function testFormDatetimeRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->datetime('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="datetime" value="2015-02-20T00:00:00+00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->datetime('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="datetime" value="2015-02-20T00:00:00+00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->datetime('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="datetime" value="' . \Carbon\Carbon::now()->format(DateTime::RFC3339) . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->datetime('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
+    }
+
+    public function testFormDatetimeLocal()
+    {
+        $form1 = $this->formBuilder->datetimeLocal('foo');
+        $form2 = $this->formBuilder->datetimeLocal('foo', '2015-02-20');
+        $form3 = $this->formBuilder->datetimeLocal('foo', \Carbon\Carbon::now());
+        $form4 = $this->formBuilder->datetimeLocal('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->datetimeLocal('foo', '2015-02-20 23:16:58');
+
+        $this->assertEquals('<input name="foo" type="datetime-local">', $form1);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="2015-02-20T00:00">', $form2);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="' . \Carbon\Carbon::now()->format('Y-m-d\TH:i') . '">',
+            $form3);
+        $this->assertEquals('<input class="span2" name="foo" type="datetime-local">', $form4);
+        $this->assertEquals('<input name="foo" type="datetime-local" value="2015-02-20T23:16">', $form5);
+    }
+
+    public function testFormDatetimeLocalRepopulation()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+        $this->setModel($model = ['date_of_birth' => ['key' => \Carbon\Carbon::now()], 'other' => 'val']);
+
+        $session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('2015-02-20');
+        $input = $this->formBuilder->datetimeLocal('name.with.dots', '2015-02-20');
+        $this->assertEquals('<input name="name.with.dots" type="datetime-local" value="2015-02-20T00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->once()->with('date.key.sub')->andReturn(null);
+        $input = $this->formBuilder->datetimeLocal('date[key][sub]', '2015-02-20');
+        $this->assertEquals('<input name="date[key][sub]" type="datetime-local" value="2015-02-20T00:00">', $input);
+
+        $session->shouldReceive('getOldInput')->with('date_of_birth.key')->andReturn(null);
+        $input1 = $this->formBuilder->datetimeLocal('date_of_birth[key]');
+        $this->assertEquals('<input name="date_of_birth[key]" type="datetime-local" value="' . \Carbon\Carbon::now()->format('Y-m-d\TH:i') . '">', $input1);
+
+        $this->setModel($model, false);
+        $input2 = $this->formBuilder->datetimeLocal('date_of_birth[key]');
+
+        $this->assertEquals($input1, $input2);
     }
 
     public function testFormTime()


### PR DESCRIPTION
I'm submitting this pull request once again as you've ignored my reply to the previous one. The problem I am referencing (as you can check by following the steps below) is not the ability to format attributes for displaying inside a form, but rather the fact that you are formatting date values only if the user provides a hard-coded value but not when retrieving them from a model (which causes the form not to interpret the value correctly). Also, your form-attribute-accessors solution does not work. So, please, take a few minutes to follow the steps below and verify what I've said. If you can demonstrate that, instead, your solution works, please provide the steps as I could not find a way.

_Steps:_
- Create a new Laravel 5.2 project and install laravelcollective/html with composer.
- Setup an sqlite database connection, delete the default migrations and the `User` model, then run the following command: `php artisan make:model -m User`
- Edit the newly created migration to reflect the following:

```
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class CreateUsersTable extends Migration
{
    /**
    * Run the migrations.
    *
    * @return void
    */
    public function up()
    {
        Schema::create('users', function (Blueprint $table) {
            $table->increments('id');
            $table->date('date_of_birth');
            $table->timestamps();
        });
    }

    /**
    * Reverse the migrations.
    *
    * @return void
    */
    public function down()
    {
        Schema::drop('users');
    }
}
```
- Edit the newly created model to reflect the following:

```
namespace App;

use Carbon\Carbon;
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    protected $fillable = ['date_of_birth'];

    protected $dates = ['date_of_birth'];

    protected $casts = ['date_of_birth' => 'date'];

    public function formDateOfBirthAttribute($value)
    {
        return Carbon::parse($value)->format('Y-m-d');
    }
}
```
- Run `php artisan make:controller UserController --resource` and edit the newly crated controller to reflect the following:

```
namespace App\Http\Controllers;

use App\Http\Requests;
use App\User;

class UserController extends Controller
{
    /**
     * Show the form for editing the specified resource.
     *
     * @param  User $user
     * @return \Illuminate\Http\Response
     */
    public function edit(User $user)
    {
        return view('users.edit', ['user' => $user]);
    }
}
```
- Create the following `\resources\views\users\edit.blade.php` view:

```
<html>
    <head></head>
    <body>
        {!! Form::model($user, ['route' => ['users.edit', $user], 'method' => 'PATCH']) !!}
            {!! Form::date('date_of_birth') !!}
        {!! Form::close() !!}
    </body>
</html>
```
- Add the following lines to your `routes.php` file:

```
Route::model('users', 'App\User');
Route::resource('users', 'UserController', ['only' => ['edit']]);
```
- Run the following commands:
  - `php artisan tinker`
  - `App\User::create(['date_of_birth' => Carbon\Carbon::parse('1989-01-19')])`
- Start the server by running `php artisan serve` and visit `http://localhost:8000/users/1/edit` (assuming your server is listening on port 8000 and the id of the record you have created on the previous step is 1)

_Effects:_
- your page displays an unpopulated date field
- if you inspect the form control you will see that the `value` attribute was actually set to `1989-01-19 00:00:00` (format that is not recognised as valid by the browser's html interpreter for a date input field)

_Conclusions:_
- by following your form-attribute-accessors solution the date is not correctly formatted and therefore the date field is not correctly populated
- your solution is not a solution
- if you run the same test with the laravelcollective/html branch I've submitted, it works
