### PR TITLE
Add PHP 7 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false


### PR DESCRIPTION
PHP 7 is the current supported PHP version, it is important to show and validate that this package is compatible :)

I'm making one pull request per branch to simplify the merging task.