### PR TITLE
Config file for default attributes

### DIFF
--- a/config/html.php
+++ b/config/html.php
@@ -1,0 +1,63 @@
+<?php
+
+// add attributes in the following html tags
+// and those attributes will be automatically
+// added in the generated html element
+// eg 'button' => ['class' => 'btn btn-primary']
+
+return [
+
+	// Html facade elements
+	'html' => [
+		'script'  => [],
+		'style'   => [],
+		'image'   => [],
+		'favicon' => [],
+		'link'    => [],
+		'mailto'  => [],
+		'dl'      => [],
+		'listing' => [],
+		'meta'    => [],
+		'tag'     => [],
+	],
+
+	// Form facade elements
+	'form' => [
+		'open'          => [],
+		'label'         => [],
+		'input'         => [],
+		'text'          => [],
+		'password'      => [],
+		'submit'        => [],
+		'email'         => [],
+		'tel'           => [],
+		'number'        => [],
+		'date'          => [],
+		'datetime'      => [],
+		'datetimeLocal' => [],
+		'time'          => [],
+		'url'           => [],
+		'file'          => [],
+		'textarea'      => [],
+		'select'        => [],
+		'option'        => [],
+		'checkable'     => [],
+		'reset'         => [],
+		'image'         => [],
+		'color'         => [],
+		'submit'        => [],
+		'button'        => [],
+	],
+
+	// Group
+	// these element groups can be added in any html tag
+	// as attribute which will add the defined group of
+	// attributes in the element
+	// eg. {!! Form::open(url('/login'), ['group' => 'login-form']) !!} will generate
+	// {!! Form::open(url('/login'), ['class' => 'form form--full-width form--login']) !!}
+	'group' => [
+		// add custom grouped elements
+		// eg. 'login-form' => ['class' => 'form form--full-width form--login']
+	],
+
+];

--- a/config/html.php
+++ b/config/html.php
@@ -7,57 +7,57 @@
 
 return [
 
-	// Html facade elements
-	'html' => [
-		'script'  => [],
-		'style'   => [],
-		'image'   => [],
-		'favicon' => [],
-		'link'    => [],
-		'mailto'  => [],
-		'dl'      => [],
-		'listing' => [],
-		'meta'    => [],
-		'tag'     => [],
-	],
+    // Html facade elements
+    'html' => [
+        'script'  => [],
+        'style'   => [],
+        'image'   => [],
+        'favicon' => [],
+        'link'    => [],
+        'mailto'  => [],
+        'dl'      => [],
+        'listing' => [],
+        'meta'    => [],
+        'tag'     => [],
+    ],
 
-	// Form facade elements
-	'form' => [
-		'open'          => [],
-		'label'         => [],
-		'input'         => [],
-		'text'          => [],
-		'password'      => [],
-		'submit'        => [],
-		'email'         => [],
-		'tel'           => [],
-		'number'        => [],
-		'date'          => [],
-		'datetime'      => [],
-		'datetimeLocal' => [],
-		'time'          => [],
-		'url'           => [],
-		'file'          => [],
-		'textarea'      => [],
-		'select'        => [],
-		'option'        => [],
-		'checkable'     => [],
-		'reset'         => [],
-		'image'         => [],
-		'color'         => [],
-		'submit'        => [],
-		'button'        => [],
-	],
+    // Form facade elements
+    'form' => [
+        'open'          => [],
+        'label'         => [],
+        'input'         => [],
+        'text'          => [],
+        'password'      => [],
+        'submit'        => [],
+        'email'         => [],
+        'tel'           => [],
+        'number'        => [],
+        'date'          => [],
+        'datetime'      => [],
+        'datetimeLocal' => [],
+        'time'          => [],
+        'url'           => [],
+        'file'          => [],
+        'textarea'      => [],
+        'select'        => [],
+        'option'        => [],
+        'checkable'     => [],
+        'reset'         => [],
+        'image'         => [],
+        'color'         => [],
+        'submit'        => [],
+        'button'        => [],
+    ],
 
-	// Group
-	// these element groups can be added in any html tag
-	// as attribute which will add the defined group of
-	// attributes in the element
-	// eg. {!! Form::open(url('/login'), ['group' => 'login-form']) !!} will generate
-	// {!! Form::open(url('/login'), ['class' => 'form form--full-width form--login']) !!}
-	'group' => [
-		// add custom grouped elements
-		// eg. 'login-form' => ['class' => 'form form--full-width form--login']
-	],
+    // Group
+    // these element groups can be added in any html tag
+    // as attribute which will add the defined group of
+    // attributes in the element
+    // eg. {!! Form::open(url('/login'), ['group' => 'login-form']) !!} will generate
+    // {!! Form::open(url('/login'), ['class' => 'form form--full-width form--login']) !!}
+    'group' => [
+        // add custom grouped elements
+        // eg. 'login-form' => ['class' => 'form form--full-width form--login']
+    ],
 
 ];

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -22,7 +22,7 @@ class FormBuilder
     /**
      * The HTML builder instance.
      *
-     * @var \Collective\Html\HtmlBuilder
+     * @var \Munza\Html\HtmlBuilder
      */
     protected $html;
 
@@ -92,7 +92,7 @@ class FormBuilder
     /**
      * Create a new form builder instance.
      *
-     * @param  \Collective\Html\HtmlBuilder               $html
+     * @param  \Munza\Html\HtmlBuilder               $html
      * @param  \Illuminate\Contracts\Routing\UrlGenerator $url
      * @param  \Illuminate\Contracts\View\Factory         $view
      * @param  string                                     $csrfToken
@@ -146,7 +146,7 @@ class FormBuilder
         // Finally, we will concatenate all of the attributes into a single string so
         // we can build out the final form open statement. We'll also append on an
         // extra value for the hidden _method field if it's needed for the form.
-        $attributes = $this->html->attributes($attributes);
+        $attributes = $this->html->attributes($attributes, 'form.open');
 
         return $this->toHtmlString('<form' . $attributes . '>' . $append);
     }
@@ -217,7 +217,7 @@ class FormBuilder
     {
         $this->labels[] = $name;
 
-        $options = $this->html->attributes($options);
+        $options = $this->html->attributes($options, 'form.label');
 
         $value = e($this->formatLabel($name, $value));
 
@@ -247,7 +247,7 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function input($type, $name, $value = null, $options = [])
+    public function input($type, $name, $value = null, $options = [], $tag = 'form.input')
     {
         if (! isset($options['name'])) {
             $options['name'] = $name;
@@ -269,7 +269,7 @@ class FormBuilder
 
         $options = array_merge($options, $merge);
 
-        return $this->toHtmlString('<input' . $this->html->attributes($options) . '>');
+        return $this->toHtmlString('<input' . $this->html->attributes($options, $tag) . '>');
     }
 
     /**
@@ -283,7 +283,7 @@ class FormBuilder
      */
     public function text($name, $value = null, $options = [])
     {
-        return $this->input('text', $name, $value, $options);
+        return $this->input('text', $name, $value, $options, 'form.text');
     }
 
     /**
@@ -296,7 +296,7 @@ class FormBuilder
      */
     public function password($name, $options = [])
     {
-        return $this->input('password', $name, '', $options);
+        return $this->input('password', $name, '', $options, 'form.password');
     }
 
     /**
@@ -310,7 +310,7 @@ class FormBuilder
      */
     public function hidden($name, $value = null, $options = [])
     {
-        return $this->input('hidden', $name, $value, $options);
+        return $this->input('hidden', $name, $value, $options, 'form.hidden');
     }
 
     /**
@@ -324,7 +324,7 @@ class FormBuilder
      */
     public function email($name, $value = null, $options = [])
     {
-        return $this->input('email', $name, $value, $options);
+        return $this->input('email', $name, $value, $options, 'form.email');
     }
 
     /**
@@ -338,7 +338,7 @@ class FormBuilder
      */
     public function tel($name, $value = null, $options = [])
     {
-        return $this->input('tel', $name, $value, $options);
+        return $this->input('tel', $name, $value, $options. 'form.tel');
     }
 
     /**
@@ -352,7 +352,7 @@ class FormBuilder
      */
     public function number($name, $value = null, $options = [])
     {
-        return $this->input('number', $name, $value, $options);
+        return $this->input('number', $name, $value, $options, 'form.number');
     }
 
     /**
@@ -370,7 +370,7 @@ class FormBuilder
             $value = $value->format('Y-m-d');
         }
 
-        return $this->input('date', $name, $value, $options);
+        return $this->input('date', $name, $value, $options, 'form.date');
     }
 
     /**
@@ -388,7 +388,7 @@ class FormBuilder
             $value = $value->format(DateTime::RFC3339);
         }
 
-        return $this->input('datetime', $name, $value, $options);
+        return $this->input('datetime', $name, $value, $options, 'form.datetime');
     }
 
     /**
@@ -406,7 +406,7 @@ class FormBuilder
             $value = $value->format('Y-m-d\TH:i');
         }
 
-        return $this->input('datetime-local', $name, $value, $options);
+        return $this->input('datetime-local', $name, $value, $options, 'form.datetimeLocal');
     }
 
     /**
@@ -420,7 +420,7 @@ class FormBuilder
      */
     public function time($name, $value = null, $options = [])
     {
-        return $this->input('time', $name, $value, $options);
+        return $this->input('time', $name, $value, $options, 'form.time');
     }
 
     /**
@@ -434,7 +434,7 @@ class FormBuilder
      */
     public function url($name, $value = null, $options = [])
     {
-        return $this->input('url', $name, $value, $options);
+        return $this->input('url', $name, $value, $options, 'form.url');
     }
 
     /**
@@ -447,7 +447,7 @@ class FormBuilder
      */
     public function file($name, $options = [])
     {
-        return $this->input('file', $name, null, $options);
+        return $this->input('file', $name, null, $options, 'form.file');
     }
 
     /**
@@ -479,7 +479,7 @@ class FormBuilder
         // Next we will convert the attributes into a string form. Also we have removed
         // the size attribute, as it was merely a short-cut for the rows and cols on
         // the element. Then we'll create the final textarea elements HTML for us.
-        $options = $this->html->attributes($options);
+        $options = $this->html->attributes($options, 'form.textarea');
 
         return $this->toHtmlString('<textarea' . $options . '>' . e($value) . '</textarea>');
     }
@@ -561,7 +561,7 @@ class FormBuilder
         // Once we have all of this HTML, we can join this into a single element after
         // formatting the attributes into an HTML "attributes" string, then we will
         // build out a final select statement, which will contain all the values.
-        $options = $this->html->attributes($options);
+        $options = $this->html->attributes($options, 'form.select');
 
         $list = implode('', $html);
 
@@ -676,7 +676,7 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options, 'form.option') . '>' . e($display) . '</option>');
     }
 
     /**
@@ -694,7 +694,7 @@ class FormBuilder
         $options = compact('selected');
         $options['value'] = '';
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options, 'form.option') . '>' . e($display) . '</option>');
     }
 
     /**
@@ -726,7 +726,7 @@ class FormBuilder
      */
     public function checkbox($name, $value = 1, $checked = null, $options = [])
     {
-        return $this->checkable('checkbox', $name, $value, $checked, $options);
+        return $this->checkable('checkbox', $name, $value, $checked, $options, 'form.checkbox');
     }
 
     /**
@@ -745,7 +745,7 @@ class FormBuilder
             $value = $name;
         }
 
-        return $this->checkable('radio', $name, $value, $checked, $options);
+        return $this->checkable('radio', $name, $value, $checked, $options, 'form.radio');
     }
 
     /**
@@ -759,7 +759,7 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function checkable($type, $name, $value, $checked, $options)
+    protected function checkable($type, $name, $value, $checked, $options, $tag)
     {
         $checked = $this->getCheckedState($type, $name, $value, $checked);
 
@@ -767,7 +767,7 @@ class FormBuilder
             $options['checked'] = 'checked';
         }
 
-        return $this->input($type, $name, $value, $options);
+        return $this->input($type, $name, $value, $options, $tag);
     }
 
     /**
@@ -864,7 +864,7 @@ class FormBuilder
      */
     public function reset($value, $attributes = [])
     {
-        return $this->input('reset', null, $value, $attributes);
+        return $this->input('reset', null, $value, $attributes, 'form.reset');
     }
 
     /**
@@ -880,7 +880,7 @@ class FormBuilder
     {
         $attributes['src'] = $this->url->asset($url);
 
-        return $this->input('image', $name, null, $attributes);
+        return $this->input('image', $name, null, $attributes, 'form.image');
     }
 
     /**
@@ -894,7 +894,7 @@ class FormBuilder
      */
     public function color($name, $value = null, $options = [])
     {
-        return $this->input('color', $name, $value, $options);
+        return $this->input('color', $name, $value, $options, 'form.color');
     }
 
     /**
@@ -907,7 +907,7 @@ class FormBuilder
      */
     public function submit($value = null, $options = [])
     {
-        return $this->input('submit', null, $value, $options);
+        return $this->input('submit', null, $value, $options, 'form.submit');
     }
 
     /**
@@ -924,7 +924,7 @@ class FormBuilder
             $options['type'] = 'button';
         }
 
-        return $this->toHtmlString('<button' . $this->html->attributes($options) . '>' . $value . '</button>');
+        return $this->toHtmlString('<button' . $this->html->attributes($options, 'form.button') . '>' . $value . '</button>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -403,7 +403,7 @@ class HtmlBuilder
         // if there is group attribute defined then fetch the group attributes
         // from the config file (html.php) and remove the group key from the
         // attribute or empty array will be returned
-        if ( array_has($attributes, 'group') ) {
+        if (array_has($attributes, 'group')) {
             $groupAttributes = config('html.group.'.array_pull($attributes, 'group')) ?: [];
         } else {
             $groupAttributes = [];
@@ -412,7 +412,7 @@ class HtmlBuilder
         // merge the fetched group attributes (from html.php) with the basic tag
         // attrbites of the config file (html.php); if there is no tag attribute 
         // is found then only the group attribute is returned
-        if ( config('html.' . $tag) != null) {
+        if (config('html.' . $tag) != null) {
             $configAttributes = $this->attributesMerge($groupAttributes, config('html.' . $tag));
         } else {
             $configAttributes = $groupAttributes;
@@ -434,11 +434,11 @@ class HtmlBuilder
 
     /**
      * Merge given attributes and default attributes.
-     * 
+     *
      * @param array $attrDefault
      * @param array $attrGiven
      * @param string $delimeter = ''
-     * 
+     *
      * @return array
      */
     public function attributesMerge($attrDefault, $attrGiven, $delimeter = ' ')
@@ -447,11 +447,11 @@ class HtmlBuilder
         
         $concated = [];
         foreach ($keys as $key) {
-            if ( isset($attrDefault[$key]) && isset($attrGiven[$key]) ) {
+            if (isset($attrDefault[$key]) && isset($attrGiven[$key])) {
                 $concated[$key] = $attrDefault[$key] . $delimeter . $attrGiven[$key];
-            } else if ( isset($attrDefault[$key]) ) {
+            } elseif (isset($attrDefault[$key])) {
                 $concated[$key] = $attrDefault[$key];
-            } else if ( isset($attrGiven[$key]) ) {
+            } elseif (isset($attrGiven[$key])) {
                 $concated[$key] = $attrGiven[$key];
             }
         }

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -410,7 +410,7 @@ class HtmlBuilder
         }
 
         // merge the fetched group attributes (from html.php) with the basic tag
-        // attrbites of the config file (html.php); if there is no tag attribute 
+        // attrbites of the config file (html.php); if there is no tag attribute
         // is found then only the group attribute is returned
         if (config('html.' . $tag) != null) {
             $configAttributes = $this->attributesMerge($groupAttributes, config('html.' . $tag));
@@ -444,7 +444,7 @@ class HtmlBuilder
     public function attributesMerge($attrDefault, $attrGiven, $delimeter = ' ')
     {
         $keys = array_unique(array_merge(array_keys($attrDefault), array_keys($attrGiven)));
-        
+
         $concated = [];
         foreach ($keys as $key) {
             if (isset($attrDefault[$key]) && isset($attrGiven[$key])) {
@@ -455,7 +455,7 @@ class HtmlBuilder
                 $concated[$key] = $attrGiven[$key];
             }
         }
-        
+
         return $concated;
     }
 

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -79,7 +79,7 @@ class HtmlBuilder
     {
         $attributes['src'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<script' . $this->attributes($attributes) . '></script>' . PHP_EOL);
+        return $this->toHtmlString('<script' . $this->attributes($attributes, 'html.script') . '></script>' . PHP_EOL);
     }
 
     /**
@@ -99,7 +99,7 @@ class HtmlBuilder
 
         $attributes['href'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<link' . $this->attributes($attributes, 'html.style') . '>' . PHP_EOL);
     }
 
     /**
@@ -117,7 +117,7 @@ class HtmlBuilder
         $attributes['alt'] = $alt;
 
         return $this->toHtmlString('<img src="' . $this->url->asset($url,
-            $secure) . '"' . $this->attributes($attributes) . '>');
+            $secure) . '"' . $this->attributes($attributes, 'html.image') . '>');
     }
 
     /**
@@ -137,7 +137,7 @@ class HtmlBuilder
 
         $attributes['href'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<link' . $this->attributes($attributes, 'html.favicon') . '>' . PHP_EOL);
     }
 
     /**
@@ -158,7 +158,7 @@ class HtmlBuilder
             $title = $url;
         }
 
-        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes) . '>' . $this->entities($title) . '</a>');
+        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes, 'html.link') . '>' . $this->entities($title) . '</a>');
     }
 
     /**
@@ -253,7 +253,7 @@ class HtmlBuilder
 
         $email = $this->obfuscate('mailto:') . $email;
 
-        return $this->toHtmlString('<a href="' . $email . '"' . $this->attributes($attributes) . '>' . $this->entities($title) . '</a>');
+        return $this->toHtmlString('<a href="' . $email . '"' . $this->attributes($attributes, 'html.mailto') . '>' . $this->entities($title) . '</a>');
     }
 
     /**
@@ -304,7 +304,7 @@ class HtmlBuilder
      */
     public function dl(array $list, array $attributes = [])
     {
-        $attributes = $this->attributes($attributes);
+        $attributes = $this->attributes($attributes, 'html.dl');
 
         $html = "<dl{$attributes}>";
 
@@ -347,7 +347,7 @@ class HtmlBuilder
             $html .= $this->listingElement($key, $type, $value);
         }
 
-        $attributes = $this->attributes($attributes);
+        $attributes = $this->attributes($attributes, 'html.listing');
 
         return $this->toHtmlString("<{$type}{$attributes}>{$html}</{$type}>");
     }
@@ -392,12 +392,34 @@ class HtmlBuilder
      * Build an HTML attribute string from an array.
      *
      * @param array $attributes
+     * @param string $tag = ''
      *
      * @return string
      */
-    public function attributes($attributes)
+    public function attributes($attributes, $tag = '')
     {
         $html = [];
+
+        // if there is group attribute defined then fetch the group attributes
+        // from the config file (html.php) and remove the group key from the
+        // attribute or empty array will be returned
+        if ( array_has($attributes, 'group') ) {
+            $groupAttributes = config('html.group.'.array_pull($attributes, 'group')) ?: [];
+        } else {
+            $groupAttributes = [];
+        }
+
+        // merge the fetched group attributes (from html.php) with the basic tag
+        // attrbites of the config file (html.php); if there is no tag attribute 
+        // is found then only the group attribute is returned
+        if ( config('html.' . $tag) != null) {
+            $configAttributes = $this->attributesMerge($groupAttributes, config('html.' . $tag));
+        } else {
+            $configAttributes = $groupAttributes;
+        }
+
+        // merge the merged config attributes with the given attribute
+        $attributes = $this->attributesMerge($configAttributes, $attributes);
 
         foreach ((array) $attributes as $key => $value) {
             $element = $this->attributeElement($key, $value);
@@ -408,6 +430,33 @@ class HtmlBuilder
         }
 
         return count($html) > 0 ? ' ' . implode(' ', $html) : '';
+    }
+
+    /**
+     * Merge given attributes and default attributes.
+     * 
+     * @param array $attrDefault
+     * @param array $attrGiven
+     * @param string $delimeter = ''
+     * 
+     * @return array
+     */
+    public function attributesMerge($attrDefault, $attrGiven, $delimeter = ' ')
+    {
+        $keys = array_unique(array_merge(array_keys($attrDefault), array_keys($attrGiven)));
+        
+        $concated = [];
+        foreach ($keys as $key) {
+            if ( isset($attrDefault[$key]) && isset($attrGiven[$key]) ) {
+                $concated[$key] = $attrDefault[$key] . $delimeter . $attrGiven[$key];
+            } else if ( isset($attrDefault[$key]) ) {
+                $concated[$key] = $attrDefault[$key];
+            } else if ( isset($attrGiven[$key]) ) {
+                $concated[$key] = $attrGiven[$key];
+            }
+        }
+        
+        return $concated;
     }
 
     /**
@@ -483,7 +532,7 @@ class HtmlBuilder
 
         $attributes = array_merge($defaults, $attributes);
 
-        return $this->toHtmlString('<meta' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<meta' . $this->attributes($attributes, 'html.meta') . '>' . PHP_EOL);
     }
 
     /**
@@ -498,7 +547,7 @@ class HtmlBuilder
     public function tag($tag, $content, array $attributes = [])
     {
         $content = is_array($content) ? implode(PHP_EOL, $content) : $content;
-        return $this->toHtmlString('<' . $tag . $this->attributes($attributes) . '>' . PHP_EOL . $this->toHtmlString($content) . PHP_EOL . '</' . $tag . '>' . PHP_EOL);
+        return $this->toHtmlString('<' . $tag . $this->attributes($attributes, 'html.tag') . '>' . PHP_EOL . $this->toHtmlString($content) . PHP_EOL . '</' . $tag . '>' . PHP_EOL);
     }
 
     /**

--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -15,6 +15,18 @@ class HtmlServiceProvider extends ServiceProvider
     protected $defer = true;
 
     /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../config/html.php' => config_path('html.php'),
+        ]);
+    }
+
+    /**
      * Register the service provider.
      *
      * @return void


### PR DESCRIPTION
Sometimes a developer needs to specify some default class for a particular html tag/element whenever they create it with Form/Html Facade. For example, if he is using Twitter Bootstrap then he might want to add `form-control` class with all the **text**, **password**, **textarea**, **email**, **number** or any **input** tag/element. Right now he needs to do as following -
```
// resources/views/welcome.blade.php
...
{!! Form::text('username', '', ['class' =>'form-control']) !!}
{!! Form::password('password', ['class' =>'form-control']) !!}
...
```
Of course this is not problem for small project. But imagine if you have lots of form with lots of form elements. In that case you need to write this same `class` attribute for each of it.
Instead, if you had a config file, you could add a `class` in that config file for a particular Form facade element; it would have been much more easier for you to manage all these default attributes for all the elements. Like - 
```
// config/html.php
...
'text'     => ['class' => 'form-control'],
'password' => ['class' => 'form-control'],
...
```
Now, all you need is to create Form facade element without mentioning the `form-control` `class` property. And if you still want to add any custom `class` then you can still mention it and it will be added after the default attributes mentioned in the config file. Like -
```
// resources/views/welcome.blade.php
...
{!! Form::text('username', '', ['class' =>'custom-class']) !!}
{!! Form::password('password']) !!}
...
```
This will generate -
```
...
<input class="form-control custom-class" name="username" type="text" value="">
<input class="form-control" name="password" type="password" value="">
...
```
You can also create a grouped attributes by specifying as following -
```
// config/html.php
...
'group' => [
    '1-3-center-col' => ['class' => 'form col-4-desktop col-4-offset-desktop col-12-tablet'],
    '1-2-center-col' => ['class' => 'form col-6-desktop col-3-offset-desktop col-12-tablet'],
],
...
```
And then you can use it in you blade file as following -
```
// resources/views/auth/login.blade.php
...
{!! Form::open(['url' => '/login', 'group' => '1-3-center-col']) !!}
    {!! Form::text('username']) !!}
    {!! Form::password('password']) !!}
{!! Form::close() !!}
...
```
This will generate -
```
...
<form class="form col-4-desktop col-4-offset-desktop col-12-tablet" method="POST" action="/auth/login" accept-charset="UTF-8">
    <input name="username" type="text" value="">
    <input name="password" type="password" value="">
</form>
...
```
The default attributes specified in the same config files for form element will still be added after the grouped attributes along with the attributes specified in the blade by the user at the end.
This is very useful when you want to avoid using too many classes in the Form facade and keep blade file clean. Also if you are using same layout in multiple blade view then to change it you just need to change the grouped attributes in the config file once if you have used above grouped attributes.

This configuration file can be published using the following command in the console -
```
php artisan vendor:publish
```
By default, there is no default attributes specified in the config file, only Html & Form facade methods are placed as array keys.

And of course,, if someone decides not to use any of these then he can just ignore everything stated above and use the package in usual way.

So what do you think about this? Is it worthy to be added into the package?