### PR TITLE
Html escaping is now optional for labels

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -210,16 +210,21 @@ class FormBuilder
      * @param  string $name
      * @param  string $value
      * @param  array  $options
+     * @param  bool   $escape_html
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function label($name, $value = null, $options = [])
+    public function label($name, $value = null, $options = [], $escape_html = true)
     {
         $this->labels[] = $name;
 
         $options = $this->html->attributes($options);
 
-        $value = e($this->formatLabel($name, $value));
+        $value = $this->formatLabel($name, $value);
+
+        if ($escape_html) {
+            $value = $this->html->entities($value);
+        }
 
         return $this->toHtmlString('<label for="' . $name . '"' . $options . '>' . $value . '</label>');
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -58,9 +58,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
     {
         $form1 = $this->formBuilder->label('foo', 'Foobar');
         $form2 = $this->formBuilder->label('foo', 'Foobar', ['class' => 'control-label']);
+        $form3 = $this->formBuilder->label('foo', 'Foobar <i>bar</i>', null, false);
 
         $this->assertEquals('<label for="foo">Foobar</label>', $form1);
         $this->assertEquals('<label for="foo" class="control-label">Foobar</label>', $form2);
+        $this->assertEquals('<label for="foo">Foobar <i>bar</i></label>', $form3);
     }
 
     public function testFormInput()


### PR DESCRIPTION
I run into this issue when I was creating a checkbox with a label that should contain a link to an agreement page. I'd like to make html escaping optional for all labels. 

Besides the added feature I think it's also an improvement because we're using $this->html->entities instead of e() to escape the value.

#167 Also reported this as an issue.