### PR TITLE
Update Form::date() to output values in RFC 3339 format

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -367,7 +367,7 @@ class FormBuilder
     public function date($name, $value = null, $options = [])
     {
         if ($value instanceof DateTime) {
-            $value = $value->format('Y-m-d');
+            $value = $value->format(DateTime::RFC3339);
         }
 
         return $this->input('date', $name, $value, $options);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -200,13 +200,13 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
     {
         $form1 = $this->formBuilder->date('foo');
         $form2 = $this->formBuilder->date('foo', '2015-02-20');
-        $form3 = $this->formBuilder->date('foo', \Carbon\Carbon::now());
+        $date3 = \Carbon\Carbon::now();
+        $form3 = $this->formBuilder->date('foo', $date3);
         $form4 = $this->formBuilder->date('foo', null, ['class' => 'span2']);
 
         $this->assertEquals('<input name="foo" type="date">', $form1);
-        $this->assertEquals('<input name="foo" type="date" value="2015-02-20">', $form2);
-        $this->assertEquals('<input name="foo" type="date" value="' . \Carbon\Carbon::now()->format('Y-m-d') . '">',
-          $form3);
+        $this->assertEquals('<input name="foo" type="date" value="2015-02-20T00:00:00+00:00">', $form2);
+        $this->assertEquals('<input name="foo" type="date" value="' . $date3->toRfc3339String() . '">', $form3);
         $this->assertEquals('<input class="span2" name="foo" type="date">', $form4);
     }
 


### PR DESCRIPTION
The HTML5 input type=date element requires the value to be in RFC 3339 format.  It's currently being output as `Y-m-d`, but RFC 3339 requires a complete date _and_ time.

See: 
http://w3c.github.io/html-reference/input.date.html#input.date.attrs.value
http://tools.ietf.org/html/rfc3339#section-5.6

Note: This could potentially be a breaking change for some people if they have written code (especially javascript) that relied on this helper outputting the old, invalid date format.  Not sure the best way to handle that other than a big, fat warning.
