### PR TITLE
Use Model::getAttribute() for fetching attribute values, in order to cast the attributes in the $casts property

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -23,16 +23,7 @@ trait FormAccessible
      */
     public function getFormValue($key)
     {
-        $value = $this->getAttributeFromArray($key);
-
-        // If the attribute is listed as a date, we will convert it to a DateTime
-        // instance on retrieval, which makes it quite convenient to work with
-        // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates())) {
-            if (! is_null($value)) {
-                $value = $this->asDateTime($value);
-            }
-        }
+        $value = $this->getAttribute($key);
 
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on

--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -40,8 +40,8 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
         $model = new ModelThatUsesForms($this->modelData);
         $this->formBuilder->setModel($model);
 
-        $this->assertEquals($model->getFormValue('string'), 'ponmlkjihgfedcba');
-        $this->assertEquals($model->getFormValue('created_at'), $this->now->timestamp);
+        $this->assertEquals($model->getFormValue('string'), 'PONMLKJIHGFEDCBA');
+        $this->assertEquals($model->getFormValue('created_at'), $this->now->timestamp-1);
     }
 
     public function testItCanStillMutateValuesForViews()
@@ -80,8 +80,11 @@ class ModelThatUsesForms extends Model
         return strtoupper($value);
     }
 
-    public function formCreatedAtAttribute(Carbon $value)
+    public function formCreatedAtAttribute($value)
     {
+        if( ! $value instanceof Carbon )
+            $value = Carbon::parse($value);
+
         return $value->timestamp;
     }
 

--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -82,8 +82,9 @@ class ModelThatUsesForms extends Model
 
     public function formCreatedAtAttribute($value)
     {
-        if( ! $value instanceof Carbon )
+        if (! $value instanceof Carbon) {
             $value = Carbon::parse($value);
+        }
 
         return $value->timestamp;
     }


### PR DESCRIPTION
Use Model::getAttribute() for fetching attribute values, in order to cast the attributes in the $casts property
- I also deleted the section where we check if the attribute is listed as a date, because that is already handled in the Model::getAttribute()
- Fixed the tests that broke with the change.
