### PR TITLE
Treat boolean attributes as HTML properties

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -447,6 +447,11 @@ class HtmlBuilder
         if (is_numeric($key)) {
             $key = $value;
         }
+        
+        // Treat boolean attributes as HTML properties
+        if (is_bool($value)) {
+            return $value ? $key : '';
+        }
 
         if (! is_null($value)) {
             return $key . '="' . e($value) . '"';

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -58,7 +58,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
             $this->htmlBuilder->image('http://example.com/image1'),
             $this->htmlBuilder->image('http://example.com/image2'),
         ];
-        
+
         $result4 = $this->htmlBuilder->tag('div', $content, ['class' => 'row']);
 
         $this->assertEquals('<p>' . PHP_EOL . 'Lorem ipsum dolor sit amet.' . PHP_EOL . '</p>' . PHP_EOL, $result1);
@@ -114,5 +114,16 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('<a href="mailto:person@example.com" class="example-link">&lt;span&gt;First Name Last&lt;/span&gt;</a>', $result1);
         $this->assertEquals('<a href="mailto:person@example.com" class="example-link"><span>First Name Last</span></a>', $result2);
+    }
+
+    public function testBooleanAttributes()
+    {
+        $result1 = $this->htmlBuilder->attributes(['my-property' => true]);
+
+        $result2 = $this->htmlBuilder->attributes(['my-property' => false]);
+
+        $this->assertEquals('my-property', trim($result1));
+
+        $this->assertEquals('', trim($result2));
     }
 }


### PR DESCRIPTION
HTML properties shouldn't have value. Attributes with boolean values will now be represented as HTML properties.

Given this Blade snippet:

``` blade
{!! Form::text('timezone', null, ['class' => 'form-control', 'placeholder' => 'Timezone', 'my-property' => true]); !!}
```

It will compile to:

``` html
<input class="form-control" placeholder="Timezone" my-property name="timezone" type="text" id="timezone">
```
