### PR TITLE
Transform the field name when getting the form value from model

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1103,7 +1103,7 @@ class FormBuilder
     protected function getModelValueAttribute($name)
     {
         if (method_exists($this->model, 'getFormValue')) {
-            return $this->model->getFormValue($name);
+            return $this->model->getFormValue($this->transformKey($name));
         }
 
         return data_get($this->model, $this->transformKey($name));


### PR DESCRIPTION
Currently, the form model accessor does not work on multi value fields such as "field[]". This pull request fixes it.