### PR TITLE
Getting form value from related model

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -39,6 +39,10 @@ trait FormAccessible
         // retrieval from the model to a form that is more useful for usage.
         if ($this->hasFormMutator($key)) {
             return $this->mutateFormAttribute($key, $value);
+        } else {
+
+            // No form mutator, let the model resolve this
+            return data_get($this, $key);
         }
 
         return $value;

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1103,7 +1103,7 @@ class FormBuilder
     protected function getModelValueAttribute($name)
     {
         if (method_exists($this->model, 'getFormValue')) {
-            return $this->model->getFormValue($name);
+            return $this->model->getFormValue($this->transformKey($name));
         }
 
         return data_get($this->model, $this->transformKey($name));

--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -25,6 +25,9 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
         $this->modelData = [
           'string'     => 'abcdefghijklmnop',
           'email'      => 'tj@tjshafer.com',
+          'address'    => [
+              'street' => 'abcde st'
+          ],
           'created_at' => $this->now,
           'updated_at' => $this->now,
         ];
@@ -42,6 +45,12 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($model->getFormValue('string'), 'ponmlkjihgfedcba');
         $this->assertEquals($model->getFormValue('created_at'), $this->now->timestamp);
+    }
+
+    public function testItCanGetRelatedValueForForms()
+    {
+        $model = new ModelThatUsesForms($this->modelData);
+        $this->assertEquals($model->getFormValue('address.street'), 'abcde st');
     }
 
     public function testItCanStillMutateValuesForViews()


### PR DESCRIPTION
When a model is using the FormAccessible trait, it is unable to get the value from related model.

Here is the example of the code, where address is the related model
`{{ Form::text('address[street1]', null, ['class' => 'form-control']) }}`

