### PR TITLE
Make escaping of labels for HTML and mailto links optional

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 
 class FormBuilder
 {
-
     use Macroable, Componentable {
         Macroable::__call as macroCall;
         Componentable::__call as componentCall;

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -147,10 +147,11 @@ class HtmlBuilder
      * @param string $title
      * @param array  $attributes
      * @param bool   $secure
+     * @param bool   $escape
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function link($url, $title = null, $attributes = [], $secure = null)
+    public function link($url, $title = null, $attributes = [], $secure = null, $escape = true)
     {
         $url = $this->url->to($url, [], $secure);
 
@@ -158,7 +159,11 @@ class HtmlBuilder
             $title = $url;
         }
 
-        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes) . '>' . $this->entities($title) . '</a>');
+        if ($escape) {
+            $title = $this->entities($title);
+        }
+
+        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
     }
 
     /**
@@ -242,18 +247,23 @@ class HtmlBuilder
      * @param string $email
      * @param string $title
      * @param array  $attributes
+     * @param bool   $escape
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function mailto($email, $title = null, $attributes = [])
+    public function mailto($email, $title = null, $attributes = [], $escape = true)
     {
         $email = $this->email($email);
 
         $title = $title ?: $email;
 
+        if ($escape) {
+            $title = $this->entities($title);
+        }
+
         $email = $this->obfuscate('mailto:') . $email;
 
-        return $this->toHtmlString('<a href="' . $email . '"' . $this->attributes($attributes) . '>' . $this->entities($title) . '</a>');
+        return $this->toHtmlString('<a href="' . $email . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 
 class HtmlBuilder
 {
-
     use Macroable, Componentable {
         Macroable::__call as macroCall;
         Componentable::__call as componentCall;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,12 +8,13 @@ if (! function_exists('link_to')) {
      * @param string $title
      * @param array  $attributes
      * @param bool   $secure
+     * @param bool   $escape
      *
      * @return string
      */
-    function link_to($url, $title = null, $attributes = [], $secure = null)
+    function link_to($url, $title = null, $attributes = [], $secure = null, $escape = true)
     {
-        return app('html')->link($url, $title, $attributes, $secure);
+        return app('html')->link($url, $title, $attributes, $secure, $escape);
     }
 }
 

--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -14,7 +14,6 @@ use Mockery as m;
 
 class FormAccessibleTest extends PHPUnit_Framework_TestCase
 {
-
     public function setUp()
     {
         Capsule::table('models')->truncate();
@@ -65,7 +64,6 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
 
 class ModelThatUsesForms extends Model
 {
-
     use FormAccessible;
 
     protected $table = 'models';
@@ -93,7 +91,6 @@ class ModelThatUsesForms extends Model
 
 class ModelThatDoesntUseForms extends Model
 {
-
     protected $table = 'models';
 
     public function getStringAttribute($value)

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -532,7 +532,6 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 class FormBuilderModelStub
 {
-
     protected $data;
 
     public function __construct(array $data = [])

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -89,4 +89,30 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->htmlBuilder->hasComponent('tweet'));
     }
+
+    public function testLink()
+    {
+        $result1 = $this->htmlBuilder->link("http://www.example.com", "<span>Example.com</span>", ["class" => "example-link"], null, true);
+
+        $result2 = $this->htmlBuilder->link("http://www.example.com", "<span>Example.com</span>", ["class" => "example-link"], null, false);
+
+        $this->assertEquals('<a href="http://www.example.com" class="example-link">&lt;span&gt;Example.com&lt;/span&gt;</a>', $result1);
+        $this->assertEquals('<a href="http://www.example.com" class="example-link"><span>Example.com</span></a>', $result2);
+    }
+
+    public function testMailto()
+    {
+        $htmlBuilder = m::mock('Collective\Html\HtmlBuilder[obfuscate,email]', [$this->urlGenerator, $this->viewFactory]);
+        $htmlBuilder->shouldReceive('obfuscate', 'email')->andReturnUsing(function() {
+            $args = func_get_args();
+            return $args[0];
+        });
+
+        $result1 = $htmlBuilder->mailto("person@example.com", "<span>First Name Last</span>", ["class" => "example-link"], true);
+
+        $result2 = $htmlBuilder->mailto("person@example.com", "<span>First Name Last</span>", ["class" => "example-link"], false);
+
+        $this->assertEquals('<a href="mailto:person@example.com" class="example-link">&lt;span&gt;First Name Last&lt;/span&gt;</a>', $result1);
+        $this->assertEquals('<a href="mailto:person@example.com" class="example-link"><span>First Name Last</span></a>', $result2);
+    }
 }

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -103,7 +103,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
     public function testMailto()
     {
         $htmlBuilder = m::mock('Collective\Html\HtmlBuilder[obfuscate,email]', [$this->urlGenerator, $this->viewFactory]);
-        $htmlBuilder->shouldReceive('obfuscate', 'email')->andReturnUsing(function() {
+        $htmlBuilder->shouldReceive('obfuscate', 'email')->andReturnUsing(function () {
             $args = func_get_args();
             return $args[0];
         });


### PR DESCRIPTION
Similar to @StefanPrintezis's request #174, this makes the entities() escaping of HTML link labels optional.  Allows for using this lib for creating (trusted/internal) links around HTML elements (<i>, <img>, <span>, etc).