### PR TITLE
Add unit tests for #190 and #191 (FormAccessor trait being inconsistent when used with getters and key transformation)

### DIFF
--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -27,6 +27,8 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
           'address'    => [
               'street' => 'abcde st'
           ],
+          'array'      => [1, 2, 3,],
+          'transform_key' => 'testing testing',
           'created_at' => $this->now,
           'updated_at' => $this->now,
         ];
@@ -50,6 +52,31 @@ class FormAccessibleTest extends PHPUnit_Framework_TestCase
     {
         $model = new ModelThatUsesForms($this->modelData);
         $this->assertEquals($model->getFormValue('address.street'), 'abcde st');
+    }
+    
+    public function testItCanUseGetAccessorValuesWhenThereAreNoFormAccessors()
+    {
+        $model = new ModelThatUsesForms($this->modelData);
+        $this->formBuilder->setModel($model);
+        
+        $this->assertEquals($this->formBuilder->getValueAttribute('email'), 'mutated@tjshafer.com');
+    }
+
+    public function testItReturnsSameResultWithAndWithoutThisFeature()
+    {
+        $modelWithAccessor = new ModelThatUsesForms($this->modelData);
+        $modelWithoutAccessor = new ModelThatDoesntUseForms($this->modelData);
+
+        $this->formBuilder->setModel($modelWithAccessor);
+        $valuesWithAccessor[] = $this->formBuilder->getValueAttribute('array');
+        $valuesWithAccessor[] = $this->formBuilder->getValueAttribute('array[0]');
+        $valuesWithAccessor[] = $this->formBuilder->getValueAttribute('transform.key');
+        $this->formBuilder->setModel($modelWithoutAccessor);
+        $valuesWithoutAccessor[] = $this->formBuilder->getValueAttribute('array');
+        $valuesWithoutAccessor[] = $this->formBuilder->getValueAttribute('array[0]');
+        $valuesWithoutAccessor[] = $this->formBuilder->getValueAttribute('transform.key');
+
+        $this->assertEquals($valuesWithAccessor, $valuesWithoutAccessor);
     }
 
     public function testItCanStillMutateValuesForViews()
@@ -95,6 +122,11 @@ class ModelThatUsesForms extends Model
     public function getCreatedAtAttribute($value)
     {
         return '1 second ago';
+    }
+
+    public function getEmailAttribute($value)
+    {
+        return 'mutated@tjshafer.com';
     }
 }
 


### PR DESCRIPTION
I actually tried to patch this 'bug' (which was still present on the last released version 5.2.4), but after writing these tests realized that they have already been fixed on this branch. For what it's worth I'm not really sure if the tests add anything or if I actually wrote them properly (since they didn't fail), but more unit tests are always better, right? 
