### PR TITLE
Make Form::option and Form::optionGroup public

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -654,7 +654,7 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function optionGroup($list, $label, $selected)
+    public function optionGroup($list, $label, $selected)
     {
         $html = [];
 
@@ -674,7 +674,7 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function option($display, $value, $selected)
+    public function option($display, $value, $selected)
     {
         $selected = $this->getSelectedValue($value, $selected);
 


### PR DESCRIPTION
Form::option and Form::optionGroup are public. This is useful for making customized selects (with duplicate keys, for instance).