### PR TITLE
Use Laravel's csrf_field()

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -198,9 +198,7 @@ class FormBuilder
      */
     public function token()
     {
-        $token = ! empty($this->csrfToken) ? $this->csrfToken : $this->session->getToken();
-
-        return $this->hidden('_token', $token);
+        return csrf_field();
     }
 
     /**


### PR DESCRIPTION
I was getting a token mismatch when trying to submit a previously invalid form. I tested by attempting to log in with invalid info, redirecting back to the login form, and attempting to log in again with valid info. Before this change, it was giving me a token mismatch error on the 2nd submission. After this change it works as expected..