### PR TITLE
Check if component/macro exists instead of relying on exceptions

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1197,16 +1197,12 @@ class FormBuilder
      */
     public function __call($method, $parameters)
     {
-        try {
+        if (static::hasComponent($method)) {
             return $this->componentCall($method, $parameters);
-        } catch (BadMethodCallException $e) {
-            //
         }
 
-        try {
+        if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
-        } catch (BadMethodCallException $e) {
-            //
         }
 
         throw new BadMethodCallException("Method {$method} does not exist.");

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -546,16 +546,12 @@ class HtmlBuilder
      */
     public function __call($method, $parameters)
     {
-        try {
+        if (static::hasComponent($method)) {
             return $this->componentCall($method, $parameters);
-        } catch (BadMethodCallException $e) {
-            //
         }
 
-        try {
+        if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
-        } catch (BadMethodCallException $e) {
-            //
         }
 
         throw new BadMethodCallException("Method {$method} does not exist.");


### PR DESCRIPTION
For 5.2 and later branches. Fixes #241.

Refs https://github.com/LaravelCollective/html/commit/4c9b44a817543bd0ef7f0ca8c8a63e5556504274.
