### PR TITLE
FormBuilder::getValueAttribute preference order

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1080,16 +1080,16 @@ class FormBuilder
      */
     public function getValueAttribute($name, $value = null)
     {
+        if (! is_null($value)) {
+            return $value;
+        }
+        
         if (is_null($name)) {
             return $value;
         }
 
         if (! is_null($this->old($name)) && $name != '_method') {
             return $this->old($name);
-        }
-
-        if (! is_null($value)) {
-            return $value;
         }
 
         if (isset($this->model)) {


### PR DESCRIPTION
Changed getValueAttribute to prefer the passed argument as value, the current solution will select a value from old() when using [] fields resulting in the wrong option being selected.
