### PR TITLE
Possibilty to add automatically rules from the FormRequest Object

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1297,7 +1297,7 @@ class FormBuilder
         foreach ($rules as $value) {
             $rule = explode(":", $value);
             
-            if(in_array($rule[0], $this->binaryRules)) {
+            if (in_array($rule[0], $this->binaryRules)) {
                 $array[$rule[0]] = $rule[1];
             }
         }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1297,7 +1297,7 @@ class FormBuilder
         foreach ($rules as $value) {
             $rule = explode(":", $value);
             
-            if(in_array($rule[0], $this->binaryRules)){
+            if(in_array($rule[0], $this->binaryRules)) {
                 $array[$rule[0]] = $rule[1];
             }
         }


### PR DESCRIPTION
Add the possiblity to get the rules from the FormRequest object. for example 
`{!! Form::number("mark", null, ["class" => "form-control", "request" => "App\Http\Requests\MarkRequest"] ) !!}`

and in the MarkRequest rules 
 `['mark' => 'required|max:20']`

results : 

`<input class="form-control" name="mark" required="required" max="20" type="number">`
