### PR TITLE
Building an attribute conditionally for a boolean value

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -288,7 +288,7 @@ class HtmlBuilder
     {
         return str_repeat('&nbsp;', $num);
     }
-    
+
     /**
      * Generate an ordered list of items.
      *
@@ -434,13 +434,19 @@ class HtmlBuilder
     /**
      * Build a single attribute element.
      *
-     * @param string $key
-     * @param string $value
+     * @param string|int $key
+     * @param string|bool $value
      *
      * @return string
      */
     protected function attributeElement($key, $value)
     {
+        // For boolean values we will assume that the attribute should be built conditionally.
+        // This works for HTML attributes such as "required".
+        if (is_bool($value)) {
+            $value = (false !== $value) ? $key : null;
+        }
+
         // For numeric keys we will assume that the key and the value are the same
         // as this will convert HTML attributes such as "required" to a correct
         // form like required="required" instead of using incorrect numerics.


### PR DESCRIPTION
This change allows to use a PHP expression as a value for HTML boolean attributes such as "required" or "disabled" as follows:

```
{!! Form::email('email', $user->email, [
    'disabled' => !$user->isConfirmed(),
]) !!}
```

W3C:
> A number of attributes in HTML5 are boolean attributes. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. 
**If the attribute is present, its value must either be the empty string or a value that is a case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace.**