### PR TITLE
Values are now encoded consistently by the formbuilder and the htmlbuilder

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -485,7 +485,7 @@ class FormBuilder
         // the element. Then we'll create the final textarea elements HTML for us.
         $options = $this->html->attributes($options);
 
-        return $this->toHtmlString('<textarea' . $options . '>' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '</textarea>');
+        return $this->toHtmlString('<textarea' . $options . '>' . $this->html->escapeAll($value). '</textarea>');
     }
 
     /**
@@ -662,7 +662,7 @@ class FormBuilder
             $html[] = $this->option($display, $value, $selected);
         }
 
-        return $this->toHtmlString('<optgroup label="' . htmlentities($label, ENT_QUOTES, 'UTF-8') . '">' . implode('', $html) . '</optgroup>');
+        return $this->toHtmlString('<optgroup label="' . $this->html->escapeAll($label) . '">' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -680,7 +680,7 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . htmlentities($display, ENT_QUOTES, 'UTF-8') . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . $this->html->escapeAll($display) . '</option>');
     }
 
     /**
@@ -698,7 +698,7 @@ class FormBuilder
         $options = compact('selected');
         $options['value'] = '';
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . htmlentities($display, ENT_QUOTES, 'UTF-8') . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . $this->html->escapeAll($display) . '</option>');
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -485,7 +485,7 @@ class FormBuilder
         // the element. Then we'll create the final textarea elements HTML for us.
         $options = $this->html->attributes($options);
 
-        return $this->toHtmlString('<textarea' . $options . '>' . e($value) . '</textarea>');
+        return $this->toHtmlString('<textarea' . $options . '>' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '</textarea>');
     }
 
     /**
@@ -662,7 +662,7 @@ class FormBuilder
             $html[] = $this->option($display, $value, $selected);
         }
 
-        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');
+        return $this->toHtmlString('<optgroup label="' . htmlentities($label, ENT_QUOTES, 'UTF-8') . '">' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -680,7 +680,7 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . htmlentities($display, ENT_QUOTES, 'UTF-8') . '</option>');
     }
 
     /**
@@ -698,7 +698,7 @@ class FormBuilder
         $options = compact('selected');
         $options['value'] = '';
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . htmlentities($display, ENT_QUOTES, 'UTF-8') . '</option>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -55,6 +55,10 @@ class HtmlBuilder
 
     /**
      * Convert all applicable characters to HTML entities.
+     *
+     * @param string $value
+     *
+     * @return string
      */
     public function escapeAll($value)
     {
@@ -395,7 +399,7 @@ class HtmlBuilder
         if (is_array($value)) {
             return $this->nestedListing($key, $type, $value);
         } else {
-            return '<li>' . $this->html->escapeAll($value) . '</li>';
+            return '<li>' . $this->escapeAll($value) . '</li>';
         }
     }
 
@@ -457,7 +461,7 @@ class HtmlBuilder
         }
 
         if (! is_null($value)) {
-            return $key . '="' . $this->html->escapeAll($value) . '"';
+            return $key . '="' . $this->escapeAll($value) . '"';
         }
     }
 

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -288,7 +288,7 @@ class HtmlBuilder
     {
         return str_repeat('&nbsp;', $num);
     }
-    
+
     /**
      * Generate an ordered list of items.
      *
@@ -387,7 +387,7 @@ class HtmlBuilder
         if (is_array($value)) {
             return $this->nestedListing($key, $type, $value);
         } else {
-            return '<li>' . e($value) . '</li>';
+            return '<li>' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '</li>';
         }
     }
 
@@ -449,7 +449,7 @@ class HtmlBuilder
         }
 
         if (! is_null($value)) {
-            return $key . '="' . e($value) . '"';
+            return $key . '="' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '"';
         }
     }
 

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -54,6 +54,14 @@ class HtmlBuilder
     }
 
     /**
+     * Convert all applicable characters to HTML entities.
+     */
+    public function escapeAll($value)
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
      * Convert entities to HTML characters.
      *
      * @param string $value
@@ -387,7 +395,7 @@ class HtmlBuilder
         if (is_array($value)) {
             return $this->nestedListing($key, $type, $value);
         } else {
-            return '<li>' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '</li>';
+            return '<li>' . $this->html->escapeAll($value) . '</li>';
         }
     }
 
@@ -449,7 +457,7 @@ class HtmlBuilder
         }
 
         if (! is_null($value)) {
-            return $key . '="' . htmlentities($value, ENT_QUOTES, 'UTF-8') . '"';
+            return $key . '="' . $this->html->escapeAll($value) . '"';
         }
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -237,13 +237,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
     {
         $form1 = $this->formBuilder->textarea('foo');
         $form2 = $this->formBuilder->textarea('foo', 'foobar');
-        $form3 = $this->formBuilder->textarea('foo', null, ['class' => 'span2']);
-        $form4 = $this->formBuilder->textarea('foo', null, ['size' => '60x15']);
+        $form3 = $this->formBuilder->textarea('foo', '&amp;');
+        $form4 = $this->formBuilder->textarea('foo', null, ['class' => 'span2']);
+        $form5 = $this->formBuilder->textarea('foo', null, ['size' => '60x15']);
 
         $this->assertEquals('<textarea name="foo" cols="50" rows="10"></textarea>', $form1);
         $this->assertEquals('<textarea name="foo" cols="50" rows="10">foobar</textarea>', $form2);
-        $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form3);
-        $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form4);
+        $this->assertEquals('<textarea name="foo" cols="50" rows="10">&amp;amp;</textarea>', $form3);
+        $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form4);
+        $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form5);
     }
 
     public function testSelect()
@@ -287,6 +289,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
                 'Large sizes' => [
                     'L' => 'Large',
                     'XL' => 'Extra Large',
+                    'XXL' => 'Extra&nbsp;Large',
                 ],
                 'S' => 'Small',
             ],
@@ -299,7 +302,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $select,
-            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option></optgroup><option value="S">Small</option></select>'
+            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option><option value="XXL">Extra&amp;nbsp;Large</option></optgroup><option value="S">Small</option></select>'
         );
     }
 
@@ -331,10 +334,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
           'size',
           ['L' => 'Large', 'S' => 'Small'],
           null,
-          ['placeholder' => 'Select One...']
+          ['placeholder' => 'Select &nbsp;One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" value="">Select &amp;nbsp;One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -237,15 +237,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
     {
         $form1 = $this->formBuilder->textarea('foo');
         $form2 = $this->formBuilder->textarea('foo', 'foobar');
-        $form3 = $this->formBuilder->textarea('foo', '&amp;');
-        $form4 = $this->formBuilder->textarea('foo', null, ['class' => 'span2']);
-        $form5 = $this->formBuilder->textarea('foo', null, ['size' => '60x15']);
+        $form3 = $this->formBuilder->textarea('foo', null, ['class' => 'span2']);
+        $form4 = $this->formBuilder->textarea('foo', null, ['size' => '60x15']);
+        $form5 = $this->formBuilder->textarea('encoded_html', '&amp;');
 
         $this->assertEquals('<textarea name="foo" cols="50" rows="10"></textarea>', $form1);
         $this->assertEquals('<textarea name="foo" cols="50" rows="10">foobar</textarea>', $form2);
-        $this->assertEquals('<textarea name="foo" cols="50" rows="10">&amp;amp;</textarea>', $form3);
-        $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form4);
-        $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form5);
+        $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form3);
+        $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form4);
+        $this->assertEquals('<textarea name="encoded_html" cols="50" rows="10">&amp;amp;</textarea>', $form5);
     }
 
     public function testSelect()
@@ -289,7 +289,6 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
                 'Large sizes' => [
                     'L' => 'Large',
                     'XL' => 'Extra Large',
-                    'XXL' => 'Extra&nbsp;Large',
                 ],
                 'S' => 'Small',
             ],
@@ -302,7 +301,18 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $select,
-            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option><option value="XXL">Extra&amp;nbsp;Large</option></optgroup><option value="S">Small</option></select>'
+            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option></optgroup><option value="S">Small</option></select>'
+        );
+
+        $select = $this->formBuilder->select(
+            'encoded_html',
+            ['no_break_space' => '&nbsp;', 'ampersand' => '&amp;', 'lower_than' => '&lt;'],
+            null
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select name="encoded_html"><option value="no_break_space">&amp;nbsp;</option><option value="ampersand">&amp;amp;</option><option value="lower_than">&amp;lt;</option></select>'
         );
     }
 
@@ -334,10 +344,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
           'size',
           ['L' => 'Large', 'S' => 'Small'],
           null,
-          ['placeholder' => 'Select &nbsp;One...']
+          ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" value="">Select &amp;nbsp;One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',
@@ -347,6 +357,16 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals($select,
           '<select name="size"><option value="">Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
+
+        $select = $this->formBuilder->select(
+            'encoded_html',
+            ['no_break_space' => '&nbsp;', 'ampersand' => '&amp;', 'lower_than' => '&lt;'],
+            null,
+            ['placeholder' => 'Select the &nbsp;']
+        );
+        $this->assertEquals($select,
+            '<select name="encoded_html"><option selected="selected" value="">Select the &amp;nbsp;</option><option value="no_break_space">&amp;nbsp;</option><option value="ampersand">&amp;amp;</option><option value="lower_than">&amp;lt;</option></select>'
+        );
     }
 
     public function testFormSelectYear()

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -39,6 +39,28 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<dl class="example"><dt>foo</dt><dd>bar</dd><dt>bing</dt><dd>baz</dd></dl>', $result);
     }
 
+    public function testOl()
+    {
+        $list = ['foo', 'bar', '&amp;'];
+
+        $attributes = ['class' => 'example'];
+
+        $ol = $this->htmlBuilder->ol($list, $attributes);
+
+        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ol>', $ol);
+    }
+
+    public function testUl()
+    {
+        $list = ['foo', 'bar', '&amp;'];
+
+        $attributes = ['class' => 'example'];
+
+        $ul = $this->htmlBuilder->ul($list, $attributes);
+
+        $this->assertEquals('<ul class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ul>', $ul);
+    }
+
     public function testMeta()
     {
         $result = $this->htmlBuilder->meta('description', 'Lorem ipsum dolor sit amet.');
@@ -58,7 +80,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
             $this->htmlBuilder->image('http://example.com/image1'),
             $this->htmlBuilder->image('http://example.com/image2'),
         ];
-        
+
         $result4 = $this->htmlBuilder->tag('div', $content, ['class' => 'row']);
 
         $this->assertEquals('<p>' . PHP_EOL . 'Lorem ipsum dolor sit amet.' . PHP_EOL . '</p>' . PHP_EOL, $result1);


### PR DESCRIPTION
I've replaced e with htmlentities().
#254 Reported this as an issue.
