### PR TITLE
Fixed nullable checked state

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -839,7 +839,7 @@ class FormBuilder
      */
     protected function getRadioCheckedState($name, $value, $checked)
     {
-        if (!is_null($checked) || $this->missingOldAndModel($name)) {
+        if ($this->missingOld($name) && (!is_null($checked) || $this->missingModel($name))) {
             return $checked;
         }
 
@@ -855,8 +855,30 @@ class FormBuilder
      */
     protected function missingOldAndModel($name)
     {
-        return (is_null($this->old($name)) && is_null($this->getModelValueAttribute($name)));
+        return $this->missingOld($name) && $this->missingModel($name);
     }
+       
+    /**
+     * Determine if old input exists for a key.
+     *
+     * @param  string $name
+     *
+     * @return bool
+     */
+    protected function missingOld($name) {
+        return is_null($this->old($name);
+    }
+                       
+    /**
+     * Determine if model exists for a key.
+     *
+     * @param  string $name
+     *
+     * @return bool
+     */
+    protected function missingModel($name) {
+        return is_null($this->getModelValueAttribute($name));
+    }                       
 
     /**
      * Create a HTML reset input element.

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -866,7 +866,7 @@ class FormBuilder
      * @return bool
      */
     protected function missingOld($name) {
-        return is_null($this->old($name);
+        return is_null($this->old($name));
     }
                        
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -865,7 +865,8 @@ class FormBuilder
      *
      * @return bool
      */
-    protected function missingOld($name) {
+    protected function missingOld($name)
+    {
         return is_null($this->old($name));
     }
                        
@@ -876,7 +877,8 @@ class FormBuilder
      *
      * @return bool
      */
-    protected function missingModel($name) {
+    protected function missingModel($name)
+    {
         return is_null($this->getModelValueAttribute($name));
     }                       
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -839,7 +839,7 @@ class FormBuilder
      */
     protected function getRadioCheckedState($name, $value, $checked)
     {
-        if ($this->missingOldAndModel($name)) {
+        if (!is_null($checked) && $this->missingOldAndModel($name)) {
             return $checked;
         }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -839,7 +839,7 @@ class FormBuilder
      */
     protected function getRadioCheckedState($name, $value, $checked)
     {
-        if (!is_null($checked) && $this->missingOldAndModel($name)) {
+        if (!is_null($checked) || $this->missingOldAndModel($name)) {
             return $checked;
         }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -880,7 +880,7 @@ class FormBuilder
     protected function missingModel($name)
     {
         return is_null($this->getModelValueAttribute($name));
-    }                       
+    }
 
     /**
      * Create a HTML reset input element.


### PR DESCRIPTION
I changed that one line, because he following happened to me:

I have a table with a "role_id" column. And I want the role to be accessible through a method on the model called "role()" - it's singular because it's a belongsTo-Relation.
After all, the name of the radio field for all the possible values for the "role_id" column should have the name "role", which is in this case the same name as the relation method.

This causes the FormBuilder to crash when it deals with form model binding, because it automatically tries to get the current value from the model (so it gets the current value with $model->{$field_name}). In this case that would fail, because the returned value is the related Eloquent model rather than the value of the "role_id" column.

So I thought I could just set the checked param (3rd param) of the checkbox call to a value which is not null (something like "$currentRadioButtonId == $model->role->id") - and in this case it would use that value to determine checked state rather then "asking" the model.  But that didn't work.

Btw: This workflow with null-value works in text fields - so if I pass a null value to the inpu, it will display the model value, otherwise it will display the value provided as a param..