### PR TITLE
Add attributes to list elements and control attribute html escaping

### DIFF
--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -61,6 +61,25 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<ul class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ul>', $ul);
     }
 
+    public function testListing()
+    {
+        $parentAttributes = ['class'=>'parClass', 'id'=>'parent'];
+        $list = [['foo', ['class'=>'someClass']], 'bar', ['&amp;', ['class'=>'class22', 'onclick'=>"alert('test')", false]], ['example']];
+
+        $listElement = $this->htmlBuilder->listing('ul', $list, $parentAttributes);
+
+        $this->assertEquals('<ul class="parClass" id="parent"><li class="someClass">foo</li><li>bar</li><li class="class22" onclick="alert(\'test\')>&amp;</li><ul><li>example</li></ul></ul>', $listElement);
+    }
+
+    public function testAttributes()
+    {
+        $attributesInput = ['attr1'=>'val1', ['attr2'=>'val2'], ['onclick'=>'alert(\'disable html escaping\')', false], 'onclick'=>'alert(\'enable html escaping\')'];
+
+        $attributesOutput = $this->attributes($attributesInput);
+
+        $this->assertEquals('attr1="val1" attr2="val2" onclick="alert(\'disable html escaping\')" onclick="alert(&#039;enable html escaping&#039;)"', $attributesOutput);
+    }
+
     public function testMeta()
     {
         $result = $this->htmlBuilder->meta('description', 'Lorem ipsum dolor sit amet.');


### PR DESCRIPTION
This commit allows you to add attributes to individual list elements (instead of just the parent list type) and allows for optional html escaping when specifying attributes.
============================================================================

-- Added support for applying attributes to listing elements.

Following syntaxes are supported for the lists (example given for ul, but
works same for ol and dl):

Html::ul([['example', ["class"=>"ex-class"]], 'Another element without
attributes', ['A simple nested element']])
=>
<ul attribute="someattr"><li class="ex-class">example</li><li>Another
element without attributes</li><ul><li>A simple nested
element</li></ul></ul>

-----------------------------------

The exact mechanics are as follows:

While specifying the $lists param, if you want to apply some attribute(s)
to that list, enclose the whole list element in an array and specify list
content as first element of array and the attributes as second element of
array: Html::ul([ ['list element', ['attribute'=>'attribute value']] ]) =>
<ul><li attribute="attribute value">list element</li></ul>

If attributes array is not specified but list element is still enclosed in
array, it is treated as nested list (default behaviour prior to this
commit): Html::ul([['example']]) => <ul><ul><li>example</li></ul></ul>

If attributes array is not specified and list is not enclosed in array, it
is treated as a simple list element without any attributes (default
behaviour prior to this commit): Html::ul(['example element']) =>
<ul><li>example element</li></ul>

So the only basic changes are: if you want to specify an attribute for the
list element, just enclose the list element in an array, specify the list
element value as first element in array and the attributes as second
element of array. Rest all of the default behaviour is attained including
the default way of applying the attributes to the ul tag.

============================================================================

-- Added support for option of disabling html escaping in attributes

While specifying attributes in attribute array, just enclose that specific
attribute in its own array with first element as the attribute=>value pair
and the second element as a boolean value to enable or disable html
escaping. Example:

[ ["attribute"=>"value_where_html_escaping_needs_to_be_disabled", false] ]

(The final boolean, false disables html escaping while true enables it
(default).)

-----------------------------------

The exact mechanics are as follows:

If attribute is not enclosed in its own array (the prior default way),
html escaping is enabled by default:
["attribute"=>"value"] => Html will be escaped (default).

If attribute is enclosed in its own array and no boolean value is
specified to enable/disable html escaping, html escaping is enabled by
default:
[ ["attribute"=>"value"] ] => Html will be escaped.

If attribute is enclosed in its own array and boolean value is specified
to enable/disable html escaping, html escaping is enabled by default:
[ ["attribute"=>"value", false] ] => Html will NOT be escaped.
[ ["attribute"=>"value", true] ] => Html will be escaped.