### PR TITLE
Add attributes to list elements and control attribute html escaping

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -396,11 +396,45 @@ class HtmlBuilder
      */
     protected function listingElement($key, $type, $value)
     {
+        $elementValue;
+        $elementAttributes = '';
+
         if (is_array($value)) {
-            return $this->nestedListing($key, $type, $value);
+            // If its a simple nested array without any other parameter
+            // such as attributes or Html escaping
+            if (count($value) === 1) {
+                return $this->nestedListing($key, $type, $value);
+            }
+
+            $elementValue = $value[0];
+            $escapeHtml = true;
+
+            // Resolve attributes if specified and handle Html-escaping for the value
+            if (count($value) > 1) {
+                // If attributes are specified, get them
+                if (is_array($value[1])) {
+                    $elementAttributes = $this->attributes($value[1]);
+                } elseif ($value[1] === false) {
+                    // If attributes are ommitted and escapeHtml value
+                    // is provided, operate with that value instead
+                    $escapeHtml = false;
+                }
+
+                // If the attributes were provided along with escapeHtml value
+                if (count($value) > 2 && $value[2] === false) {
+                    $escapeHtml = false;
+                }
+
+                if ($escapeHtml) {
+                    $elementValue = $this->escapeAll($elementValue);
+                }
+            }
         } else {
-            return '<li>' . $this->escapeAll($value) . '</li>';
+            // Assume Html escaping is required by default
+           $elementValue = $this->escapeAll($value);
         }
+
+        return "<li{$elementAttributes}>{$elementValue}</li>";
     }
 
     /**
@@ -453,15 +487,55 @@ class HtmlBuilder
      */
     protected function attributeElement($key, $value)
     {
-        // For numeric keys we will assume that the key and the value are the same
-        // as this will convert HTML attributes such as "required" to a correct
-        // form like required="required" instead of using incorrect numerics.
-        if (is_numeric($key)) {
-            $key = $value;
+        $attributeValue;
+        $escapeHtml = false;
+
+        // The attribute value has two possibilities:
+        /* 1: The array: First element is attribute key and the value.
+           Second element is if html escaping should be enabled or not.
+           Example: ["attribute"=>"value", true]
+        */
+        // 2: Just the attribute and value pair. Example: ["attribute"=>"value]
+
+        if (is_array($value)) {
+            // Get the keys to use indices
+            // The last element (boolean) controls Html escaping
+            // Previous element (first) are actual attributes
+            $keys = array_keys($value);
+            $key = $keys[0];
+            $attributeValue = $value[$key];
+            // If array doesn't have spec for Html escaping, assume true
+            // or Html escaping is enabled explicitely
+            if (count($value) === 1 || $value[$keys[1]]) {
+                $escapeHtml = true;
+            }
+        } elseif ($value != '') {
+            if (is_numeric($key)) {
+                if ($value === false) {
+                    // In this case, it is ok for attributeValue to be null
+                    // since we only need this parameter to check if
+                    // html escaping is required and value will not be used
+                    $escapeHtml = false;
+                } else {
+                    // For numeric keys we will assume that the key and the value are the same
+                    // as this will convert HTML attributes such as "required" to a     correct
+                    // form like required="required" instead of using incorrect numerics.
+                    $key = $attributeValue = $value;
+                    $escapeHtml = true;
+                }
+            } else {
+                // If nothing is specified for html escaping
+                // assume it needs to be done
+                $attributeValue = $value;
+                $escapeHtml = true;
+            }
         }
 
-        if (! is_null($value)) {
-            return $key . '="' . $this->escapeAll($value) . '"';
+        if (isset($attributeValue) && ! is_null($attributeValue)) {
+            if ($escapeHtml) {
+                $attributeValue = $this->escapeAll($attributeValue);
+            }
+            return $key . '="' . $attributeValue . '"';
         }
     }
 
@@ -572,4 +646,5 @@ class HtmlBuilder
 
         throw new BadMethodCallException("Method {$method} does not exist.");
     }
+
 }

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -47,18 +47,17 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $ol = $this->htmlBuilder->ol($list, $attributes);
 
-        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ol>', $ol);
+        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;</li></ol>', $ol);
     }
 
     public function testUl()
     {
-        $list = ['foo', 'bar', '&amp;'];
+        $parentAttributes = ['class'=>'par-class', 'id'=>'parent'];
+        $list = [['foo', ['class'=>'someClass']], 'bar', ['&amp;', ['class'=>'class22', 'onclick'=>"alert('test')", false]], ['example']];
 
-        $attributes = ['class' => 'example'];
+        $listElement = $this->htmlBuilder->ul($list, $parentAttributes);
 
-        $ul = $this->htmlBuilder->ul($list, $attributes);
-
-        $this->assertEquals('<ul class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ul>', $ul);
+        $this->assertEquals('<ul class="par-class" id="parent"><li class="someClass">foo</li><li>bar</li><li class="class22" onclick="alert(&#039;test&#039;)>&amp;</li><ul><li>example</li></ul></ul>', $listElement);
     }
 
     public function testMeta()


### PR DESCRIPTION
Add attributes to individual list elements and enable/disable html escaping for attributes
---------------------------------

-- Added support for applying attributes to listing elements.

Following syntaxes are supported for the lists (example given for ul, but
works same for ol and dl):

Html::ul([['example', ["class"=>"ex-class"]], 'Another element without
attributes', ['A simple nested element']])
=>
<ul attribute="someattr"><li class="ex-class">example</li><li>Another
element without attributes</li><ul><li>A simple nested
element</li></ul></ul>

-----------------------------------

The exact mechanics are as follows:

While specifying the $lists param, if you want to apply some attribute(s)
to that list, enclose the whole list element in an array and specify list
content as first element of array and the attributes as second element of
array: Html::ul([ ['list element', ['attribute'=>'attribute value']] ]) =>
<ul><li attribute="attribute value">list element</li></ul>

If attributes array is not specified but list element is still enclosed in
array, it is treated as nested list (default behaviour prior to this
commit): Html::ul([['example']]) => <ul><ul><li>example</li></ul></ul>

If attributes array is not specified and list is not enclosed in array, it
is treated as a simple list element without any attributes (default
behaviour prior to this commit): Html::ul(['example element']) =>
<ul><li>example element</li></ul>

So the only basic changes are: if you want to specify an attribute for the
list element, just enclose the list element in an array, specify the list
element value as first element in array and the attributes as second
element of array. Rest all of the default behaviour is attained including
the default way of applying the attributes to the ul tag.

============================================================================

-- Added support for option of disabling html escaping in attributes

While specifying attributes in attribute array, just enclose that specific
attribute in its own array with first element as the attribute=>value pair
and the second element as a boolean value to enable or disable html
escaping. Example:

[ ["attribute"=>"value_where_html_escaping_needs_to_be_disabled", false] ]

(The final boolean, false disables html escaping while true enables it
(default).)

-----------------------------------

The exact mechanics are as follows:

If attribute is not enclosed in its own array (the prior default way),
html escaping is enabled by default:
["attribute"=>"value"] => Html will be escaped (default).

If attribute is enclosed in its own array and no boolean value is
specified to enable/disable html escaping, html escaping is enabled by
default:
[ ["attribute"=>"value"] ] => Html will be escaped.

If attribute is enclosed in its own array and boolean value is specified
to enable/disable html escaping, html escaping is enabled by default:
[ ["attribute"=>"value", false] ] => Html will NOT be escaped.
[ ["attribute"=>"value", true] ] => Html will be escaped.