### PR TITLE
5.4 Fixes

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -198,7 +198,7 @@ class FormBuilder
      */
     public function token()
     {
-        $token = ! empty($this->csrfToken) ? $this->csrfToken : $this->session->getToken();
+        $token = ! empty($this->csrfToken) ? $this->csrfToken : $this->session->token();
 
         return $this->hidden('_token', $token);
     }

--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -49,7 +49,7 @@ class HtmlServiceProvider extends ServiceProvider
     protected function registerFormBuilder()
     {
         $this->app->singleton('form', function ($app) {
-            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->getToken());
+            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->token());
 
             return $form->setSessionStore($app['session.store']);
         });


### PR DESCRIPTION
From the 5.4 upgrade guide:

All calls to the ->getToken() method should be changed to ->token().