### PR TITLE
[5.4] Allow select options to have attributes

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -531,21 +531,28 @@ class FormBuilder
      * @param  string $name
      * @param  array  $list
      * @param  string $selected
-     * @param  array  $options
+     * @param  array  $selectAttributes
+     * @param  array  $optionsAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function select($name, $list = [], $selected = null, $options = [])
+    public function select(
+        $name,
+        array $list = [],
+        $selected = null,
+        array $selectAttributes = [],
+        array $optionsAttributes = []
+    )
     {
         // When building a select box the "value" attribute is really the selected one
         // so we will use that when checking the model or session for a value which
         // should provide a convenient method of re-populating the forms on post.
         $selected = $this->getValueAttribute($name, $selected);
 
-        $options['id'] = $this->getIdAttribute($name, $options);
+        $selectAttributes['id'] = $this->getIdAttribute($name, $selectAttributes);
 
-        if (! isset($options['name'])) {
-            $options['name'] = $name;
+        if (! isset($selectAttributes['name'])) {
+            $selectAttributes['name'] = $name;
         }
 
         // We will simply loop through the options and build an HTML value for each of
@@ -553,23 +560,24 @@ class FormBuilder
         // all together into one single HTML element that can be put on the form.
         $html = [];
 
-        if (isset($options['placeholder'])) {
-            $html[] = $this->placeholderOption($options['placeholder'], $selected);
-            unset($options['placeholder']);
+        if (isset($selectAttributes['placeholder'])) {
+            $html[] = $this->placeholderOption($selectAttributes['placeholder'], $selected);
+            unset($selectAttributes['placeholder']);
         }
 
         foreach ($list as $value => $display) {
-            $html[] = $this->getSelectOption($display, $value, $selected);
+            $optionAttributes = isset($optionsAttributes[$value]) ? $optionsAttributes[$value] : [];
+            $html[] = $this->getSelectOption($display, $value, $selected, $optionAttributes);
         }
 
         // Once we have all of this HTML, we can join this into a single element after
         // formatting the attributes into an HTML "attributes" string, then we will
         // build out a final select statement, which will contain all the values.
-        $options = $this->html->attributes($options);
+        $selectAttributes = $this->html->attributes($selectAttributes);
 
         $list = implode('', $html);
 
-        return $this->toHtmlString("<select{$options}>{$list}</select>");
+        return $this->toHtmlString("<select{$selectAttributes}>{$list}</select>");
     }
 
     /**
@@ -633,16 +641,17 @@ class FormBuilder
      * @param  string $display
      * @param  string $value
      * @param  string $selected
+     * @param  array  $attributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function getSelectOption($display, $value, $selected)
+    public function getSelectOption($display, $value, $selected, array $attributes = [])
     {
         if (is_array($display)) {
-            return $this->optionGroup($display, $value, $selected);
+            return $this->optionGroup($display, $value, $selected, $attributes);
         }
 
-        return $this->option($display, $value, $selected);
+        return $this->option($display, $value, $selected, $attributes);
     }
 
     /**
@@ -651,15 +660,16 @@ class FormBuilder
      * @param  array  $list
      * @param  string $label
      * @param  string $selected
+     * @param  array  $attributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function optionGroup($list, $label, $selected)
+    protected function optionGroup($list, $label, $selected, array $attributes = [])
     {
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->option($display, $value, $selected);
+            $html[] = $this->option($display, $value, $selected, $attributes);
         }
 
         return $this->toHtmlString('<optgroup label="' . $this->html->escapeAll($label) . '">' . implode('', $html) . '</optgroup>');
@@ -671,14 +681,15 @@ class FormBuilder
      * @param  string $display
      * @param  string $value
      * @param  string $selected
+     * @param  array  $attributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function option($display, $value, $selected)
+    protected function option($display, $value, $selected, array $attributes = [])
     {
         $selected = $this->getSelectedValue($value, $selected);
 
-        $options = ['value' => $value, 'selected' => $selected];
+        $options = ['value' => $value, 'selected' => $selected] + $attributes;
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . $this->html->escapeAll($display) . '</option>');
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -314,6 +314,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             $select,
             '<select name="encoded_html"><option value="no_break_space">&amp;nbsp;</option><option value="ampersand">&amp;amp;</option><option value="lower_than">&amp;lt;</option></select>'
         );
+
+        $select = $this->formBuilder->select(
+            'size',
+            ['L' => 'Large', 'S' => 'Small'],
+            null,
+            [],
+            ['L' => ['data-foo' => 'bar', 'disabled']]
+        );
+        $this->assertEquals($select,
+            '<select name="size"><option value="L" data-foo="bar" disabled="disabled">Large</option><option value="S">Small</option></select>');
+
     }
 
     public function testFormSelectRepopulation()


### PR DESCRIPTION
It's the second try to add support for custom attributes in `option` tag. The PR is inspired by https://github.com/LaravelCollective/html/pull/129 and @mlantz comments. 