### PR TITLE
[5.4] Replaced htmlentites() with htmlspecialchars()

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -50,7 +50,7 @@ class HtmlBuilder
      */
     public function entities($value)
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', false);
     }
 
     /**
@@ -62,7 +62,7 @@ class HtmlBuilder
      */
     public function escapeAll($value)
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
As stated in #265 
I didn't change the name of the function, because it still creates html entities.