### PR TITLE
Turn off encoding for existing html entities for some labels and options

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -662,7 +662,7 @@ class FormBuilder
             $html[] = $this->option($display, $value, $selected);
         }
 
-        return $this->toHtmlString('<optgroup label="' . $this->html->escapeAll($label) . '">' . implode('', $html) . '</optgroup>');
+        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -680,7 +680,7 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . $this->html->escapeAll($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
     }
 
     /**
@@ -698,7 +698,7 @@ class FormBuilder
         $options = compact('selected');
         $options['value'] = '';
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . $this->html->escapeAll($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -399,7 +399,7 @@ class HtmlBuilder
         if (is_array($value)) {
             return $this->nestedListing($key, $type, $value);
         } else {
-            return '<li>' . $this->escapeAll($value) . '</li>';
+            return '<li>' . e($value) . '</li>';
         }
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -239,13 +239,13 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $form2 = $this->formBuilder->textarea('foo', 'foobar');
         $form3 = $this->formBuilder->textarea('foo', null, ['class' => 'span2']);
         $form4 = $this->formBuilder->textarea('foo', null, ['size' => '60x15']);
-        $form5 = $this->formBuilder->textarea('encoded_html', '&amp;');
+        $form5 = $this->formBuilder->textarea('encoded_html', '&');
 
         $this->assertEquals('<textarea name="foo" cols="50" rows="10"></textarea>', $form1);
         $this->assertEquals('<textarea name="foo" cols="50" rows="10">foobar</textarea>', $form2);
         $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form3);
         $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form4);
-        $this->assertEquals('<textarea name="encoded_html" cols="50" rows="10">&amp;amp;</textarea>', $form5);
+        $this->assertEquals('<textarea name="encoded_html" cols="50" rows="10">&amp;</textarea>', $form5);
     }
 
     public function testSelect()
@@ -306,13 +306,13 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $select = $this->formBuilder->select(
             'encoded_html',
-            ['no_break_space' => '&nbsp;', 'ampersand' => '&amp;', 'lower_than' => '&lt;'],
+            ['css_star' => '&#9733;'],
             null
         );
 
         $this->assertEquals(
             $select,
-            '<select name="encoded_html"><option value="no_break_space">&amp;nbsp;</option><option value="ampersand">&amp;amp;</option><option value="lower_than">&amp;lt;</option></select>'
+            '<select name="encoded_html"><option value="css_star">&#9733;</option></select>'
         );
     }
 
@@ -365,7 +365,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             ['placeholder' => 'Select the &nbsp;']
         );
         $this->assertEquals($select,
-            '<select name="encoded_html"><option selected="selected" value="">Select the &amp;nbsp;</option><option value="no_break_space">&amp;nbsp;</option><option value="ampersand">&amp;amp;</option><option value="lower_than">&amp;lt;</option></select>'
+            '<select name="encoded_html"><option selected="selected" value="">Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
         );
     }
 

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -47,7 +47,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $ol = $this->htmlBuilder->ol($list, $attributes);
 
-        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ol>', $ol);
+        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;</li></ol>', $ol);
     }
 
     public function testUl()
@@ -58,7 +58,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $ul = $this->htmlBuilder->ul($list, $attributes);
 
-        $this->assertEquals('<ul class="example"><li>foo</li><li>bar</li><li>&amp;amp;</li></ul>', $ul);
+        $this->assertEquals('<ul class="example"><li>foo</li><li>bar</li><li>&amp;</li></ul>', $ul);
     }
 
     public function testMeta()


### PR DESCRIPTION
 Fix the current lack of entities support in labels/options

#296 