### PR TITLE
Respect HtmlString in HtmlBuilder::entities()

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -50,7 +50,7 @@ class HtmlBuilder
      */
     public function entities($value)
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+        return e($value);
     }
 
     /**


### PR DESCRIPTION
`Collective\Html\HtmlBuilder::entities()` didn't respect `Illuminate\Support\HtmlString`. The simplest way to keep inline with Laravel is to use their html encode function `e()`.