### PR TITLE
Added seach() method to FormBuilder

### DIFF
--- a/src/function hidden
+++ b/src/function hidden
@@ -320,6 +320,20 @@ class FormBuilder
     }
 
     /**
+     * Create a search input field.
+     *
+     * @param  string $name
+     * @param  string $value
+     * @param  array  $options
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    public function search($name, $value = null, $options = [])
+    {
+        return $this->input('search', $name, $value, $options);
+    }
+
+    /**
      * Create an e-mail input field.
      *
      * @param  string $name

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -166,6 +166,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<input class="span2" name="foo" type="hidden">', $form3);
     }
 
+    public function testFormSearch()
+    {
+        $form1 = $this->formBuilder->search('foo');
+        $form2 = $this->formBuilder->search('foo', 'foobar');
+        $form3 = $this->formBuilder->search('foo', null, ['class' => 'span2']);
+
+        $this->assertEquals('<input name="foo" type="search">', $form1);
+        $this->assertEquals('<input name="foo" type="search" value="foobar">', $form2);
+        $this->assertEquals('<input class="span2" name="foo" type="search">', $form3);
+    }
+
     public function testFormEmail()
     {
         $form1 = $this->formBuilder->email('foo');


### PR DESCRIPTION
If `email`, `tel` and `number` are all included, shouldn't we let `search` join the party too?! 