### PR TITLE
Add support for view errors key which are array

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1104,7 +1104,7 @@ class FormBuilder
             $hasNullMiddleware = app("Illuminate\Contracts\Http\Kernel")
                 ->hasMiddleware(ConvertEmptyStringsToNull::class);
 
-            if ($hasNullMiddleware && is_null($this->old($name)) && $this->view->shared('errors')->count() > 0) {
+            if ($hasNullMiddleware && is_null($this->old($name)) && count($this->view->shared('errors')) > 0) {
                 return null;
             }
         }


### PR DESCRIPTION
In my situation, the 'errors' key within the view is not a collection object and instead is an array, therefore this fix will allow for arrays to be read here instead.