### PR TITLE
Fix for #339

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1111,7 +1111,7 @@ class FormBuilder
     public function getValueAttribute($name, $value = null)
     {
         if ($name == '_token') {
-            return $this->csrfToken;
+            return $this->csrfToken ?: $value;
         }
 
         if (is_null($name)) {


### PR DESCRIPTION
5.4.5 broke the `_token` field because the value got overwritten by `$this->csrfToken` which is null/empty. Because the value of the field gets set in `token()`, I added a conditional to not override the value if it's empty.

Hopefully I did this correctly. Please let me know if I didn't :)