### PR TITLE
Bug fix for 5.4

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -61,7 +61,7 @@ class HtmlServiceProvider extends ServiceProvider
     protected function registerFormBuilder()
     {
         $this->app->singleton('form', function ($app) {
-            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->getToken(), $app['request']);
+            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->token(), $app['request']);
 
             return $form->setSessionStore($app['session.store']);
         });


### PR DESCRIPTION
`getToken()` is now renamed to `token();`

<img width="604" alt="upgrade_guide_-_laravel_-_the_php_framework_for_web_artisans" src="https://cloud.githubusercontent.com/assets/685928/26293213/253431fa-3eee-11e7-8eef-078760a4fa57.png">
