### PR TITLE
Solve problem when using select with multiple option set

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -760,7 +760,7 @@ class FormBuilder
     protected function getSelectedValue($value, $selected)
     {
         if (is_array($selected)) {
-            return in_array($value, $selected, true) ? 'selected' : null;
+            return in_array($value, $selected, false) ? 'selected' : null;
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }


### PR DESCRIPTION
When validating a form with a select field with multiple option set, values in the array received by the controller are strings, not ints as the third parameter of the select expects.
Thus, when a validation fails, the old function cannot fill select values as the in_array vrification was strict.
I don't know in which case this verification have to be strict, but certainly the case described above is one in which the cannot be strict.