### PR TITLE
Removing strict check for multiple select

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -760,7 +760,7 @@ class FormBuilder
     protected function getSelectedValue($value, $selected)
     {
         if (is_array($selected)) {
-            return in_array($value, $selected, true) ? 'selected' : null;
+            return in_array($value, $selected) ? 'selected' : null;
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -760,7 +760,7 @@ class FormBuilder
     protected function getSelectedValue($value, $selected)
     {
         if (is_array($selected)) {
-            return in_array($value, $selected) ? 'selected' : null;
+            return in_array((string) $value, $selected) ? 'selected' : null;
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }


### PR DESCRIPTION
If you have an array:

````
$values = [
    1 => 'A',
    2 => 'B',
    3 => 'C'
];
````

The form param will get a string value, and it won't auto select the options when getting these values from `Request`.

Is there any strong reason for this to be `strict`?  I see that right bellow we don't really care about type when it's not a multiple select or value is a collection:

````
$selected->contains($value) ? 'selected' : null;
````

````
return ((string) $value == (string) $selected) ? 'selected' : null;
````