### PR TITLE
Dont enforce disabled/hidden placeholder

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -741,9 +741,7 @@ class FormBuilder
 
         $options = [
             'selected' => $selected,
-            'disabled' => 'disabled',
-            'hidden' => 'hidden',
-            'value' => ''
+            'value' => '',
         ];
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');


### PR DESCRIPTION
Fixes https://github.com/LaravelCollective/html/issues/347

**Background** 
This PR essentially reverts this PR: https://github.com/LaravelCollective/html/commit/410943c5e19fbdee374d1ed9c59a43b2a365e66d changes the way the placeholder value behaves in the select (dropdown) input.

**Changes**  
- Removes disabled and hidden options on placeholder
 
**To Verify**    
- checkout branch `git checkout <branch-name>`
- verify placeholder is selectable