### PR TITLE
Allow to control if passed input value should be resolved

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -262,10 +262,11 @@ class FormBuilder
      * @param  string $name
      * @param  string $value
      * @param  array  $options
+     * @param  bool   $resolveValue
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function input($type, $name, $value = null, $options = [])
+    public function input($type, $name, $value = null, $options = [], $resolveValue = true)
     {
         $this->type = $type;
 
@@ -278,7 +279,7 @@ class FormBuilder
         // in the model instance if one is set. Otherwise we will just use empty.
         $id = $this->getIdAttribute($name, $options);
 
-        if (! in_array($type, $this->skipValueTypes)) {
+        if (! in_array($type, $this->skipValueTypes) && $resolveValue) {
             $value = $this->getValueAttribute($name, $value);
         }
 
@@ -325,12 +326,13 @@ class FormBuilder
      * @param  string $name
      * @param  string $value
      * @param  array  $options
+     * @param  bool   $resolveValue
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function hidden($name, $value = null, $options = [])
+    public function hidden($name, $value = null, $options = [], $resolveValue = true)
     {
-        return $this->input('hidden', $name, $value, $options);
+        return $this->input('hidden', $name, $value, $options, $resolveValue);
     }
 
     /**
@@ -1094,7 +1096,7 @@ class FormBuilder
         // method spoofer hidden input to the form. This allows us to use regular
         // form to initiate PUT and DELETE requests in addition to the typical.
         if (in_array($method, $this->spoofedMethods)) {
-            $appendage .= $this->hidden('_method', $method);
+            $appendage .= $this->hidden('_method', $method, [], false);
         }
 
         // If the method is something other than GET we will go ahead and attach the

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -121,6 +121,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<input name="foo-check" type="checkbox" value="1">', $form6);
     }
 
+    public function testFormInputPreventsValueResolve()
+    {
+        $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Contracts\Session\Session'));
+
+        $session->shouldReceive('getOldInput')->never();
+
+        $form = $this->formBuilder->input('hidden', 'foo', 'bar', [], false);
+
+        $this->assertEquals('<input name="foo" type="hidden" value="bar">', $form);
+    }
+
     public function testMacroField()
     {
         $this->formBuilder->macro('data_field', function ($name, $value, $data) {


### PR DESCRIPTION
These changes gives option for developers to prevent passed value from being overwritten with value returned by method `getValueAttribute()`. In my opinion it could be used with hidden input, which value user shouldn't be able to edit. 

Personally I faced a problem using hidden input with arrays, for example this leads to error: `htmlentities() expects parameter 1 to be string, array given` because it takes an array from request or old input.
`
    {!! Form::hidden('foo[]', 'bar') !!}
    {!! Form::hidden('foo[]', 'baz') !!}
`

I believe this solves problems stated on #350 