### PR TITLE
Fix missing method in Laravel 5.4

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -61,7 +61,7 @@ class HtmlServiceProvider extends ServiceProvider
     protected function registerFormBuilder()
     {
         $this->app->singleton('form', function ($app) {
-            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->getToken(), $app['request']);
+            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->token(), $app['request']);
 
             return $form->setSessionStore($app['session.store']);
         });


### PR DESCRIPTION
getToken() is token() in Laravel 5.4