### PR TITLE
Make Request Optional

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -49,6 +49,12 @@ class FormBuilder
      */
     protected $csrfToken;
 
+	/**
+	 * Consider Request variables while auto fill.
+	 * @var bool
+	 */
+    protected $considerRequest = false;
+
     /**
      * The session store implementation.
      *
@@ -108,6 +114,7 @@ class FormBuilder
      * @param  \Illuminate\Contracts\Routing\UrlGenerator $url
      * @param  \Illuminate\Contracts\View\Factory         $view
      * @param  string                                     $csrfToken
+     * @param  Request                                    $request
      */
     public function __construct(HtmlBuilder $html, UrlGenerator $url, Factory $view, $csrfToken, Request $request = null)
     {
@@ -1174,6 +1181,15 @@ class FormBuilder
         }
     }
 
+	/**
+	 * Take Request in fill process
+	 * @param bool $consider
+	 */
+	public function considerRequest($consider = true)
+	{
+		$this->considerRequest = $consider;
+	}
+
     /**
      * Get value from current Request
      * @param $name
@@ -1181,9 +1197,13 @@ class FormBuilder
      */
     protected function request($name)
     {
-        if (!isset($this->request)) {
-            return null;
-        }
+		if (!$this->considerRequest) {
+			return null;
+		}
+
+		if (!isset($this->request)) {
+			return null;
+		}
 
         return $this->request->input($this->transformKey($name));
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -49,10 +49,10 @@ class FormBuilder
      */
     protected $csrfToken;
 
-	/**
-	 * Consider Request variables while auto fill.
-	 * @var bool
-	 */
+    /**
+     * Consider Request variables while auto fill.
+     * @var bool
+     */
     protected $considerRequest = false;
 
     /**
@@ -1181,14 +1181,14 @@ class FormBuilder
         }
     }
 
-	/**
-	 * Take Request in fill process
-	 * @param bool $consider
-	 */
-	public function considerRequest($consider = true)
-	{
-		$this->considerRequest = $consider;
-	}
+    /**
+     * Take Request in fill process
+     * @param bool $consider
+     */
+    public function considerRequest($consider = true)
+    {
+        $this->considerRequest = $consider;
+    }
 
     /**
      * Get value from current Request
@@ -1197,13 +1197,13 @@ class FormBuilder
      */
     protected function request($name)
     {
-		if (!$this->considerRequest) {
-			return null;
-		}
+        if (!$this->considerRequest) {
+            return null;
+        }
 
-		if (!isset($this->request)) {
-			return null;
-		}
+        if (!isset($this->request)) {
+            return null;
+        }
 
         return $this->request->input($this->transformKey($name));
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -30,10 +30,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'GET', [
             "person" => [
                 "name" => "John",
-                "surname" => "Doe"
+                "surname" => "Doe",
             ],
-            "aggree" => 1,
-            "checkbox_array" => [1,2,3]
+            "agree" => 1,
+            "checkbox_array" => [1, 2, 3],
         ]);
 
         $request = Request::createFromBase($request);
@@ -51,14 +51,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testRequestValue()
     {
-        $name = $this->formBuilder->text("person[name]");
-        $surname = $this->formBuilder->text("person[surname]");
+        $this->formBuilder->considerRequest();
+        $name = $this->formBuilder->text("person[name]", "Not John");
+        $surname = $this->formBuilder->text("person[surname]", "Not Doe");
         $this->assertEquals('<input name="person[name]" type="text" value="John">', $name);
         $this->assertEquals('<input name="person[surname]" type="text" value="Doe">', $surname);
 
-        $checked = $this->formBuilder->checkbox("aggree", 1);
+        $checked = $this->formBuilder->checkbox("agree", 1);
         $unchecked = $this->formBuilder->checkbox("no_value", 1);
-        $this->assertEquals('<input checked="checked" name="aggree" type="checkbox" value="1">', $checked);
+        $this->assertEquals('<input checked="checked" name="agree" type="checkbox" value="1">', $checked);
         $this->assertEquals('<input name="no_value" type="checkbox" value="1">', $unchecked);
 
         $checked_array = $this->formBuilder->checkbox("checkbox_array[]", 1);
@@ -66,10 +67,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<input checked="checked" name="checkbox_array[]" type="checkbox" value="1">', $checked_array);
         $this->assertEquals('<input name="checkbox_array[]" type="checkbox" value="4">', $unchecked_array);
 
-        $checked = $this->formBuilder->radio("aggree", 1);
+        $checked = $this->formBuilder->radio("agree", 1);
         $unchecked = $this->formBuilder->radio("no_value", 1);
-        $this->assertEquals('<input checked="checked" name="aggree" type="radio" value="1">', $checked);
+        $this->assertEquals('<input checked="checked" name="agree" type="radio" value="1">', $checked);
         $this->assertEquals('<input name="no_value" type="radio" value="1">', $unchecked);
+
+        // now we check that Request is ignored and value take precedence
+        $this->formBuilder->considerRequest(false);
+        $name = $this->formBuilder->text("person[name]", "Not John");
+        $surname = $this->formBuilder->text("person[surname]", "Not Doe");
+        $this->assertEquals('<input name="person[name]" type="text" value="Not John">', $name);
+        $this->assertEquals('<input name="person[surname]" type="text" value="Not Doe">', $surname);
     }
 
     public function testOpeningForm()


### PR DESCRIPTION
Initially I proposed making this optional but PR was merged without discussion about that.
So I make `Request` optional and you need `Form::considerRequest(true)` for enable it.

https://github.com/LaravelCollective/html/issues/369
https://github.com/LaravelCollective/html/issues/375