### PR TITLE
Change getToken method by token in HtmlServiceProvider

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -61,7 +61,7 @@ class HtmlServiceProvider extends ServiceProvider
     protected function registerFormBuilder()
     {
         $this->app->singleton('form', function ($app) {
-            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->getToken(), $app['request']);
+            $form = new FormBuilder($app['html'], $app['url'], $app['view'], $app['session.store']->token(), $app['request']);
 
             return $form->setSessionStore($app['session.store']);
         });


### PR DESCRIPTION
Hello,

the method getToken of Illuminate/Session/Store is removed in laravel 5.4
i'm updating the HtmlServiceProvider to use the token method instead

thanks.