### PR TITLE
Added $optgroupsAttributes parameter to select method.

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -87,7 +87,7 @@ trait FormAccessible
 
         $mutator = collect($methods)
           ->first(function (ReflectionMethod $method) use ($key) {
-              return $method->getName() == 'form' . Str::studly($key) . 'Attribute';
+              return $method->getName() === 'form' . Str::studly($key) . 'Attribute';
           });
 
         return (bool) $mutator;

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -565,6 +565,7 @@ class FormBuilder
      * @param  string $selected
      * @param  array  $selectAttributes
      * @param  array  $optionsAttributes
+     * @param  array  $optgroupsAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
@@ -573,7 +574,8 @@ class FormBuilder
         $list = [],
         $selected = null,
         array $selectAttributes = [],
-        array $optionsAttributes = []
+        array $optionsAttributes = [],
+        array $optgroupsAttributes = []
     ) {
         $this->type = 'select';
 
@@ -599,8 +601,9 @@ class FormBuilder
         }
 
         foreach ($list as $value => $display) {
-            $optionAttributes = isset($optionsAttributes[$value]) ? $optionsAttributes[$value] : [];
-            $html[] = $this->getSelectOption($display, $value, $selected, $optionAttributes);
+            $optionAttributes = $optionsAttributes[$value] ?? [];
+            $optgroupAttributes = $optgroupsAttributes[$value] ?? [];
+            $html[] = $this->getSelectOption($display, $value, $selected, $optionAttributes, $optgroupAttributes);
         }
 
         // Once we have all of this HTML, we can join this into a single element after
@@ -675,13 +678,14 @@ class FormBuilder
      * @param  string $value
      * @param  string $selected
      * @param  array  $attributes
+     * @param  array  $optgroupAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function getSelectOption($display, $value, $selected, array $attributes = [])
+    public function getSelectOption($display, $value, $selected, array $attributes = [], array $optgroupAttributes = [])
     {
         if (is_array($display)) {
-            return $this->optionGroup($display, $value, $selected, $attributes);
+            return $this->optionGroup($display, $value, $selected, $optgroupAttributes, $attributes);
         }
 
         return $this->option($display, $value, $selected, $attributes);
@@ -694,18 +698,21 @@ class FormBuilder
      * @param  string $label
      * @param  string $selected
      * @param  array  $attributes
+     * @param  array  $optionsAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function optionGroup($list, $label, $selected, array $attributes = [])
+    protected function optionGroup($list, $label, $selected, array $attributes = [], array $optionsAttributes = [])
     {
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->option($display, $value, $selected, $attributes);
-        }
+            $optionAttributes = $optionsAttributes[$value] ?? [];
 
-        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');
+            $html[] = $this->option($display, $value, $selected, $optionAttributes);
+        }
+        
+        return $this->toHtmlString('<optgroup label="' . e($label) . '"' . $this->html->attributes($attributes) . '>' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -724,7 +731,12 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected] + $attributes;
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        $string = '<option' . $this->html->attributes($options) . '>';
+        if ($display !== null) {
+            $string .= e($display) . '</option>';
+        }
+
+        return $this->toHtmlString($string);
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -775,7 +775,7 @@ class FormBuilder
             return $selected->contains($value) ? 'selected' : null;
         }
 
-        return ((string) $value == (string) $selected) ? 'selected' : null;
+        return ((string) $value === (string) $selected) ? 'selected' : null;
     }
 
     /**
@@ -856,7 +856,7 @@ class FormBuilder
                 return $this->getRadioCheckedState($name, $value, $checked);
 
             default:
-                return $this->getValueAttribute($name) == $value;
+                return $this->getValueAttribute($name) === $value;
         }
     }
 
@@ -909,7 +909,7 @@ class FormBuilder
             return $checked;
         }
 
-        return $this->getValueAttribute($name) == $value;
+        return $this->getValueAttribute($name) === $value;
     }
 
     /**
@@ -1008,7 +1008,7 @@ class FormBuilder
     {
         $method = strtoupper($method);
 
-        return $method != 'GET' ? 'POST' : $method;
+        return $method !== 'GET' ? 'POST' : $method;
     }
 
     /**
@@ -1110,7 +1110,7 @@ class FormBuilder
         // If the method is something other than GET we will go ahead and attach the
         // CSRF token to the form, as this can't hurt and is convenient to simply
         // always have available on every form the developers creates for them.
-        if ($method != 'GET') {
+        if ($method !== 'GET') {
             $appendage .= $this->token();
         }
 
@@ -1152,7 +1152,7 @@ class FormBuilder
 
         $old = $this->old($name);
 
-        if (! is_null($old) && $name != '_method') {
+        if (! is_null($old) && $name !== '_method') {
             return $old;
         }
 
@@ -1163,7 +1163,7 @@ class FormBuilder
             if ($hasNullMiddleware
                 && is_null($old)
                 && is_null($value)
-                && !is_null($this->view->shared('errors'))
+                && ! is_null($this->view->shared('errors'))
                 && count($this->view->shared('errors')) > 0
             ) {
                 return null;
@@ -1171,7 +1171,7 @@ class FormBuilder
         }
 
         $request = $this->request($name);
-        if (!is_null($request)) {
+        if (! is_null($request)) {
             return $request;
         }
 
@@ -1191,7 +1191,7 @@ class FormBuilder
      */
     protected function request($name)
     {
-        if (!isset($this->request)) {
+        if (! isset($this->request)) {
             return null;
         }
 
@@ -1229,16 +1229,16 @@ class FormBuilder
             $key = $this->transformKey($name);
             $payload = $this->session->getOldInput($key);
 
-            if (!is_array($payload)) {
+            if (! is_array($payload)) {
                 return $payload;
             }
 
-            if (!in_array($this->type, ['select', 'checkbox'])) {
-                if (!isset($this->payload[$key])) {
+            if (! in_array($this->type, ['select', 'checkbox'])) {
+                if (! isset($this->payload[$key])) {
                     $this->payload[$key] = collect($payload);
                 }
 
-                if (!empty($this->payload[$key])) {
+                if (! empty($this->payload[$key])) {
                     $value = $this->payload[$key]->shift();
                     return $value;
                 }
@@ -1255,7 +1255,7 @@ class FormBuilder
      */
     public function oldInputIsEmpty()
     {
-        return (isset($this->session) && count($this->session->getOldInput()) == 0);
+        return (isset($this->session) && count($this->session->getOldInput()) === 0);
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -357,7 +357,7 @@ class HtmlBuilder
     {
         $html = '';
 
-        if (count($list) == 0) {
+        if (count($list) === 0) {
             return $html;
         }
 
@@ -451,7 +451,7 @@ class HtmlBuilder
         }
 
         // Treat boolean attributes as HTML properties
-        if (is_bool($value) && $key != 'value') {
+        if (is_bool($value) && $key !== 'value') {
             return $value ? $key : '';
         }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -403,6 +403,37 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         );
 
         $select = $this->formBuilder->select(
+            'size',
+            [
+                'Large sizes' => [
+                    'L' => 'Large',
+                    'XL' => 'Extra Large',
+                ],
+                'M' => 'Medium',
+                'Small sizes' => [
+                    'S' => 'Small',
+                    'XS' => 'Extra Small',
+                ],
+            ],
+            null,
+            [],
+            [
+                'Large sizes' => [
+                    'L' => ['disabled']
+                ],
+                'M' => ['disabled'],
+            ],
+            [
+                'Small sizes' => ['disabled'],
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select name="size"><optgroup label="Large sizes"><option value="L" disabled>Large</option><option value="XL">Extra Large</option></optgroup><option value="M" disabled>Medium</option><optgroup label="Small sizes" disabled><option value="S">Small</option><option value="XS">Extra Small</option></optgroup></select>'
+        );
+
+        $select = $this->formBuilder->select(
             'encoded_html',
             ['no_break_space' => '&nbsp;', 'ampersand' => '&amp;', 'lower_than' => '&lt;'],
             null


### PR DESCRIPTION
Addresses the concerns in #129. This PR does the following:

1. Adds a new $optgroupsAttributes parameter to the _select_ method which is used to add attributes to optgroups. Previously attributes applied to a an array element that was an optgroup would apply the attributes to every option belonging to the optgroup (rather than the optgroup itself).
2. Increases the depth of $optionsAttributes by 1. To add attributes to options inside an optgroup, use the optgroup name as the key with an array of options and their attributes as the value. Previously there was no way to add attributes to options belonging to an optgroup individually.

See the formBuilderTest changes for an example implementation.