### PR TITLE
improve select to handle multi level array

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -658,15 +658,32 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function optionGroup($list, $label, $selected)
+    protected function optionGroup($list, $label, $selected,$level = 0)
     {
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->option($display, $value, $selected);
-        }
+            if (is_array($display))
+            {
+                $html[] = $this->optionGroup($display, $value, $selected,$level+1);
+            }
+            else
+            {
+                $chiledLevel = $level;
+                if ($level > 0 && $display == reset($list))
+                {
+                    $chiledLevel = $level-1;
+                }
 
-        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');
+                $html[] = $this->option($display, $value, $selected,$chiledLevel);
+            }
+        }
+        // as browser || HTML dosn't support multi levet optgroup we just add options
+        if ($level > 0)
+        {
+            return implode('', $html);
+        }
+        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>')."\n\n";
     }
 
     /**
@@ -678,13 +695,13 @@ class FormBuilder
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function option($display, $value, $selected)
+    protected function option($display, $value, $selected,$level = 0)
     {
         $selected = $this->getSelectedValue($value, $selected);
 
         $options = ['value' => $value, 'selected' => $selected];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' .(($level > 0) ? str_repeat('-',$level).' ' : ''). e($display) . '</option>')."\n";
     }
 
     /**


### PR DESCRIPTION
if form::select method called with multi dimensional array it failed 
this commit fix that and nest the extra dimensional as normal option with `-` prefix 