### PR TITLE
Fix bug select placeholder not hidden

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -744,7 +744,7 @@ class FormBuilder
             'value' => '',
         ];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden="hidden">' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden=\"hidden\">' . e($display) . '</option>');
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -744,7 +744,7 @@ class FormBuilder
             'value' => '',
         ];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden=\"hidden\">' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden>' . e($display) . '</option>');
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -744,7 +744,7 @@ class FormBuilder
             'value' => '',
         ];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden="hidden">' . e($display) . '</option>');
     }
 
     /**


### PR DESCRIPTION
Bug is place holder still show in select list.
```
{!! Form::select('test', ['asdsad'=>'asdasd', 'zxczxc'=>'zxczxc'], null, ['class'=>'form-control', 'placeholder'=>'Test select.']) !!}
```