### PR TITLE
Support attributes by value on options in optGroup

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -702,7 +702,8 @@ class FormBuilder
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->option($display, $value, $selected, $attributes);
+            $optionAttributes = isset($attributes[$value]) ? $attributes[$value] : $attributes;
+            $html[] = $this->option($display, $value, $selected, $optionAttributes);
         }
 
         return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');


### PR DESCRIPTION
Hello,

i'm proposing this change to support setting attributes by value on options that are in optGroup.

For example we can do :
```
[
    'photos' => [
         1 => ['data-text' => 'photo 1'],
         ...
    ],
   'videos' => [
        ...
    ]
]
```
to add a data-text attribute on the option with the value 1 on the optgroup photos.

thanks