### PR TITLE
[5.6] Form method of hidden input '_method' is preserved on next request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "illuminate/database": "5.6.x-dev",
-        "mockery/mockery": "~0.9.4",
+        "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~5.4"
     },
     "autoload": {

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1243,7 +1243,7 @@ class FormBuilder
      */
     public function oldInputIsEmpty()
     {
-        return (isset($this->session) && count($this->session->getOldInput()) == 0);
+        return (isset($this->session) && count((array) $this->session->getOldInput()) == 0);
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1159,7 +1159,7 @@ class FormBuilder
         }
 
         $request = $this->request($name);
-        if (!is_null($request)) {
+        if (! is_null($request) && $name != '_method') {
             return $request;
         }
 


### PR DESCRIPTION
_FYI: This pull request was already merged in the [5.4](https://github.com/LaravelCollective/html/tree/5.4) branch but not in the [master](https://github.com/LaravelCollective/html/tree/master) branch_

E.G. when you submit a form with a `PATCH` method and then you submit another form which use a `DELETE` method instead, the [`FormBuilder::getValueAttribute()`](https://github.com/LaravelCollective/html/blob/f905913a3ab7ca639b69138aab28baa01d400034/src/FormBuilder.php#L1135) method use the previous value of the hidden input `_method` attribute.
So the value is replaced by `PATCH` instead of the desired `DELETE` value.

Maybe related to https://github.com/LaravelCollective/html/issues/350#issuecomment-309899542

PS: I use AJAX/XHR to submit my forms.
So I don't have any HTTP redirection between my two forms submit, just DOM replacements on the Browser

_The original pull request for Laravel 5.4 is [here](https://github.com/LaravelCollective/html/pull/395)_
_And the pul request for Laravel 5.5 is [here](https://github.com/LaravelCollective/html/pull/460)_