### PR TITLE
Fix some inputs treated like nestedModel when using an accessor

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -43,7 +43,7 @@ trait FormAccessible
 
         $keys = explode('.', $key);
 
-        if ($this->isNestedModel($keys[0])) {
+        if (count($keys) > 1 && $this->isNestedModel($keys[0])) {
             $relatedModel = $this->getRelation($keys[0]);
 
             unset($keys[0]);


### PR DESCRIPTION
When adding the trait FormAccessible to a model, the method getFormValue treats some inputs like nestedModel wrongly!
Because of it some checkboxes came unchecked.