### PR TITLE
Proposal: Escape HTML entities in `src`-attribute

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -162,7 +162,7 @@ class HtmlBuilder
             $title = $this->entities($title);
         }
 
-        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
+        return $this->toHtmlString('<a href="' . $this->entities($url) . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
     }
 
     /**

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -118,8 +118,11 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $result2 = $this->htmlBuilder->link("http://www.example.com", "<span>Example.com</span>", ["class" => "example-link"], null, false);
 
+        $result3 = $this->htmlBuilder->link("https://a.com/b?id=4&not_id=5", "URL which needs escaping");
+
         $this->assertEquals('<a href="http://www.example.com" class="example-link">&lt;span&gt;Example.com&lt;/span&gt;</a>', $result1);
         $this->assertEquals('<a href="http://www.example.com" class="example-link"><span>Example.com</span></a>', $result2);
+        $this->assertEquals('<a href="https://a.com/b?id=4&amp;not_id=5">URL which needs escaping</a>', $result3);
     }
 
     public function testMailto()


### PR DESCRIPTION
Currently, `link()` fails to escape HTML entities in the URL provided. 

Example: Given the URL `https://a.com/b?id=4&not_id=5`, `link()` produces the following HTML:

```html
<a href="https://a.com/b?id=4&not_id=5">URL which needs escaping</a>
```

Chrome and Safari both interpret the URL as `https://a.com/b?id=4¬_id=5`, which is clearly not intended.

(Resubmitting of #420 to master.)