### PR TITLE
Fix some inputs treated like nestedModel when using an accessor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/http": "5.5.x-dev",
-        "illuminate/routing": "5.5.x-dev",
-        "illuminate/session": "5.5.x-dev",
-        "illuminate/support": "5.5.x-dev",
-        "illuminate/view": "5.5.x-dev"
+        "illuminate/http": "5.5.*",
+        "illuminate/routing": "5.5.*",
+        "illuminate/session": "5.5.*",
+        "illuminate/support": "5.5.*",
+        "illuminate/view": "5.5.*"
     },
     "require-dev": {
-        "illuminate/database": "5.5.x-dev",
+        "illuminate/database": "5.5.*",
         "mockery/mockery": "~0.9.4",
         "phpunit/phpunit": "~5.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "laravelcollective/html",
     "description": "HTML and Form Builders for the Laravel Framework",
     "license": "MIT",
-    "homepage": "http://laravelcollective.com",
+    "homepage": "https://laravelcollective.com",
     "support": {
         "issues": "https://github.com/LaravelCollective/html/issues",
         "source": "https://github.com/LaravelCollective/html"

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/http": "5.5.*",
-        "illuminate/routing": "5.5.*",
-        "illuminate/session": "5.5.*",
-        "illuminate/support": "5.5.*",
-        "illuminate/view": "5.5.*"
+        "illuminate/http": "5.6.x-dev",
+        "illuminate/routing": "5.6.x-dev",
+        "illuminate/session": "5.6.x-dev",
+        "illuminate/support": "5.6.x-dev",
+        "illuminate/view": "5.6.x-dev"
     },
     "require-dev": {
-        "illuminate/database": "5.5.*",
+        "illuminate/database": "5.6.x-dev",
         "mockery/mockery": "~0.9.4",
         "phpunit/phpunit": "~5.4"
     },
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,17 @@
             "src/helpers.php"
         ]
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Collective\\Html\\HtmlServiceProvider"
+            ],
+            "aliases": {
+                "Form": "Collective\\Html\\FormFacade",
+                "Html": "Collective\\Html\\HtmlFacade"
+            }
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         ]
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "5.5-dev"
+        },
         "laravel": {
             "providers": [
                 "Collective\\Html\\HtmlServiceProvider"

--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -87,7 +87,7 @@ trait FormAccessible
 
         $mutator = collect($methods)
           ->first(function (ReflectionMethod $method) use ($key) {
-              return $method->getName() == 'form' . Str::studly($key) . 'Attribute';
+              return $method->getName() === 'form' . Str::studly($key) . 'Attribute';
           });
 
         return (bool) $mutator;

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -741,9 +741,7 @@ class FormBuilder
 
         $options = [
             'selected' => $selected,
-            'disabled' => 'disabled',
-            'hidden' => 'hidden',
-            'value' => ''
+            'value' => '',
         ];
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
@@ -760,7 +758,7 @@ class FormBuilder
     protected function getSelectedValue($value, $selected)
     {
         if (is_array($selected)) {
-            return in_array($value, $selected, true) ? 'selected' : null;
+            return in_array($value, $selected, true) || in_array((string) $value, $selected, true) ? 'selected' : null;
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }
@@ -1192,11 +1190,10 @@ class FormBuilder
      * Get the model value that should be assigned to the field.
      *
      * @param  string $name
-     * @param  mixed  $model
      *
      * @return mixed
      */
-    protected function getModelValueAttribute($name, $model = null)
+    protected function getModelValueAttribute($name)
     {
         $key = $this->transformKey($name);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -865,7 +865,7 @@ class FormBuilder
             return false;
         }
 
-        if ($this->missingOldAndModel($name) && !$request) {
+        if ($this->missingOldAndModel($name) && is_null($request)) {
             return $checked;
         }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -565,6 +565,7 @@ class FormBuilder
      * @param  string $selected
      * @param  array  $selectAttributes
      * @param  array  $optionsAttributes
+     * @param  array  $optgroupsAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
@@ -573,7 +574,8 @@ class FormBuilder
         $list = [],
         $selected = null,
         array $selectAttributes = [],
-        array $optionsAttributes = []
+        array $optionsAttributes = [],
+        array $optgroupsAttributes = []
     ) {
         $this->type = 'select';
 
@@ -599,8 +601,9 @@ class FormBuilder
         }
 
         foreach ($list as $value => $display) {
-            $optionAttributes = isset($optionsAttributes[$value]) ? $optionsAttributes[$value] : [];
-            $html[] = $this->getSelectOption($display, $value, $selected, $optionAttributes);
+            $optionAttributes = $optionsAttributes[$value] ?? [];
+            $optgroupAttributes = $optgroupsAttributes[$value] ?? [];
+            $html[] = $this->getSelectOption($display, $value, $selected, $optionAttributes, $optgroupAttributes);
         }
 
         // Once we have all of this HTML, we can join this into a single element after
@@ -675,13 +678,14 @@ class FormBuilder
      * @param  string $value
      * @param  string $selected
      * @param  array  $attributes
+     * @param  array  $optgroupAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function getSelectOption($display, $value, $selected, array $attributes = [])
+    public function getSelectOption($display, $value, $selected, array $attributes = [], array $optgroupAttributes = [])
     {
         if (is_array($display)) {
-            return $this->optionGroup($display, $value, $selected, $attributes);
+            return $this->optionGroup($display, $value, $selected, $optgroupAttributes, $attributes);
         }
 
         return $this->option($display, $value, $selected, $attributes);
@@ -694,18 +698,21 @@ class FormBuilder
      * @param  string $label
      * @param  string $selected
      * @param  array  $attributes
+     * @param  array  $optionsAttributes
      *
      * @return \Illuminate\Support\HtmlString
      */
-    protected function optionGroup($list, $label, $selected, array $attributes = [])
+    protected function optionGroup($list, $label, $selected, array $attributes = [], array $optionsAttributes = [])
     {
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->option($display, $value, $selected, $attributes);
-        }
+            $optionAttributes = $optionsAttributes[$value] ?? [];
 
-        return $this->toHtmlString('<optgroup label="' . e($label) . '">' . implode('', $html) . '</optgroup>');
+            $html[] = $this->option($display, $value, $selected, $optionAttributes);
+        }
+        
+        return $this->toHtmlString('<optgroup label="' . e($label) . '"' . $this->html->attributes($attributes) . '>' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -724,7 +731,12 @@ class FormBuilder
 
         $options = ['value' => $value, 'selected' => $selected] + $attributes;
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display) . '</option>');
+        $string = '<option' . $this->html->attributes($options) . '>';
+        if ($display !== null) {
+            $string .= e($display) . '</option>';
+        }
+
+        return $this->toHtmlString($string);
     }
 
     /**
@@ -763,7 +775,7 @@ class FormBuilder
             return $selected->contains($value) ? 'selected' : null;
         }
 
-        return ((string) $value == (string) $selected) ? 'selected' : null;
+        return ((string) $value === (string) $selected) ? 'selected' : null;
     }
 
     /**
@@ -844,7 +856,7 @@ class FormBuilder
                 return $this->getRadioCheckedState($name, $value, $checked);
 
             default:
-                return $this->getValueAttribute($name) == $value;
+                return $this->getValueAttribute($name) === $value;
         }
     }
 
@@ -897,7 +909,7 @@ class FormBuilder
             return $checked;
         }
 
-        return $this->getValueAttribute($name) == $value;
+        return $this->getValueAttribute($name) === $value;
     }
 
     /**
@@ -996,7 +1008,7 @@ class FormBuilder
     {
         $method = strtoupper($method);
 
-        return $method != 'GET' ? 'POST' : $method;
+        return $method !== 'GET' ? 'POST' : $method;
     }
 
     /**
@@ -1098,7 +1110,7 @@ class FormBuilder
         // If the method is something other than GET we will go ahead and attach the
         // CSRF token to the form, as this can't hurt and is convenient to simply
         // always have available on every form the developers creates for them.
-        if ($method != 'GET') {
+        if ($method !== 'GET') {
             $appendage .= $this->token();
         }
 
@@ -1140,7 +1152,7 @@ class FormBuilder
 
         $old = $this->old($name);
 
-        if (! is_null($old) && $name != '_method') {
+        if (! is_null($old) && $name !== '_method') {
             return $old;
         }
 
@@ -1151,7 +1163,7 @@ class FormBuilder
             if ($hasNullMiddleware
                 && is_null($old)
                 && is_null($value)
-                && !is_null($this->view->shared('errors'))
+                && ! is_null($this->view->shared('errors'))
                 && count($this->view->shared('errors')) > 0
             ) {
                 return null;
@@ -1159,7 +1171,7 @@ class FormBuilder
         }
 
         $request = $this->request($name);
-        if (!is_null($request)) {
+        if (! is_null($request)) {
             return $request;
         }
 
@@ -1179,7 +1191,7 @@ class FormBuilder
      */
     protected function request($name)
     {
-        if (!isset($this->request)) {
+        if (! isset($this->request)) {
             return null;
         }
 
@@ -1217,16 +1229,16 @@ class FormBuilder
             $key = $this->transformKey($name);
             $payload = $this->session->getOldInput($key);
 
-            if (!is_array($payload)) {
+            if (! is_array($payload)) {
                 return $payload;
             }
 
-            if (!in_array($this->type, ['select', 'checkbox'])) {
-                if (!isset($this->payload[$key])) {
+            if (! in_array($this->type, ['select', 'checkbox'])) {
+                if (! isset($this->payload[$key])) {
                     $this->payload[$key] = collect($payload);
                 }
 
-                if (!empty($this->payload[$key])) {
+                if (! empty($this->payload[$key])) {
                     $value = $this->payload[$key]->shift();
                     return $value;
                 }
@@ -1243,7 +1255,7 @@ class FormBuilder
      */
     public function oldInputIsEmpty()
     {
-        return (isset($this->session) && count($this->session->getOldInput()) == 0);
+        return (isset($this->session) && count($this->session->getOldInput()) === 0);
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -78,7 +78,7 @@ class HtmlBuilder
     {
         $attributes['src'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<script' . $this->attributes($attributes) . '></script>' . PHP_EOL);
+        return $this->toHtmlString('<script' . $this->attributes($attributes) . '></script>');
     }
 
     /**
@@ -98,7 +98,7 @@ class HtmlBuilder
 
         $attributes['href'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>');
     }
 
     /**
@@ -136,7 +136,7 @@ class HtmlBuilder
 
         $attributes['href'] = $this->url->asset($url, $secure);
 
-        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<link' . $this->attributes($attributes) . '>');
     }
 
     /**
@@ -511,7 +511,7 @@ class HtmlBuilder
 
         $attributes = array_merge($defaults, $attributes);
 
-        return $this->toHtmlString('<meta' . $this->attributes($attributes) . '>' . PHP_EOL);
+        return $this->toHtmlString('<meta' . $this->attributes($attributes) . '>');
     }
 
     /**
@@ -525,8 +525,8 @@ class HtmlBuilder
      */
     public function tag($tag, $content, array $attributes = [])
     {
-        $content = is_array($content) ? implode(PHP_EOL, $content) : $content;
-        return $this->toHtmlString('<' . $tag . $this->attributes($attributes) . '>' . PHP_EOL . $this->toHtmlString($content) . PHP_EOL . '</' . $tag . '>' . PHP_EOL);
+        $content = is_array($content) ? implode('', $content) : $content;
+        return $this->toHtmlString('<' . $tag . $this->attributes($attributes) . '>' . $this->toHtmlString($content) . '</' . $tag . '>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -357,7 +357,7 @@ class HtmlBuilder
     {
         $html = '';
 
-        if (count($list) == 0) {
+        if (count($list) === 0) {
             return $html;
         }
 
@@ -451,7 +451,7 @@ class HtmlBuilder
         }
 
         // Treat boolean attributes as HTML properties
-        if (is_bool($value) && $key != 'value') {
+        if (is_bool($value) && $key !== 'value') {
             return $value ? $key : '';
         }
 

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -162,7 +162,7 @@ class HtmlBuilder
             $title = $this->entities($title);
         }
 
-        return $this->toHtmlString('<a href="' . $url . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
+        return $this->toHtmlString('<a href="' . $this->entities($url) . '"' . $this->attributes($attributes) . '>' . $title . '</a>');
     }
 
     /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -403,6 +403,37 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         );
 
         $select = $this->formBuilder->select(
+            'size',
+            [
+                'Large sizes' => [
+                    'L' => 'Large',
+                    'XL' => 'Extra Large',
+                ],
+                'M' => 'Medium',
+                'Small sizes' => [
+                    'S' => 'Small',
+                    'XS' => 'Extra Small',
+                ],
+            ],
+            null,
+            [],
+            [
+                'Large sizes' => [
+                    'L' => ['disabled']
+                ],
+                'M' => ['disabled'],
+            ],
+            [
+                'Small sizes' => ['disabled'],
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select name="size"><optgroup label="Large sizes"><option value="L" disabled>Large</option><option value="XL">Extra Large</option></optgroup><option value="M" disabled>Medium</option><optgroup label="Small sizes" disabled><option value="S">Small</option><option value="XS">Extra Small</option></optgroup></select>'
+        );
+
+        $select = $this->formBuilder->select(
             'encoded_html',
             ['no_break_space' => '&nbsp;', 'ampersand' => '&amp;', 'lower_than' => '&lt;'],
             null

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use Illuminate\Session\Store;
 use Mockery as m;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase
@@ -421,6 +422,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals($select,
             '<select name="size"><option value="L" data-foo="bar" disabled>Large</option><option value="S">Small</option></select>');
+
+        $store = new Store('name', new \SessionHandler());
+        $store->put('_old_input', ['countries' => ['1']]);
+        $this->formBuilder->setSessionStore($store);
+
+        $result = $this->formBuilder->select('countries', [1 => 'L', 2 => 'M']);
+
+        $this->assertEquals(
+            '<select name="countries"><option value="1" selected="selected">L</option><option value="2">M</option></select>',
+            $result
+        );
     }
 
     public function testSelectCollection()
@@ -467,7 +479,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" disabled="disabled" hidden="hidden" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',
@@ -476,7 +488,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option disabled="disabled" hidden="hidden" value="">Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option value="">Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
             'encoded_html',
@@ -485,7 +497,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             ['placeholder' => 'Select the &nbsp;']
         );
         $this->assertEquals($select,
-            '<select name="encoded_html"><option selected="selected" disabled="disabled" hidden="hidden" value="">Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
+            '<select name="encoded_html"><option selected="selected" value="">Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
         );
     }
 

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -65,7 +65,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
     {
         $result = $this->htmlBuilder->meta('description', 'Lorem ipsum dolor sit amet.');
 
-        $this->assertEquals('<meta name="description" content="Lorem ipsum dolor sit amet.">' . PHP_EOL, $result);
+        $this->assertEquals('<meta name="description" content="Lorem ipsum dolor sit amet.">', $result);
     }
 
     public function testTag()
@@ -83,17 +83,17 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $result4 = $this->htmlBuilder->tag('div', $content, ['class' => 'row']);
 
-        $this->assertEquals('<p>' . PHP_EOL . 'Lorem ipsum dolor sit amet.' . PHP_EOL . '</p>' . PHP_EOL, $result1);
-        $this->assertEquals('<p class="text-center">' . PHP_EOL . 'Lorem ipsum dolor sit amet.' . PHP_EOL . '</p>' . PHP_EOL, $result2);
-        $this->assertEquals('<div class="row">' . PHP_EOL . '<p>Lorem ipsum dolor sit amet.</p>' . PHP_EOL . '</div>' . PHP_EOL, $result3);
-        $this->assertEquals('<div class="row">' . PHP_EOL . '<img src="http://example.com/image1">' . PHP_EOL . '<img src="http://example.com/image2">' . PHP_EOL . '</div>' . PHP_EOL, $result4);
+        $this->assertEquals('<p>Lorem ipsum dolor sit amet.</p>', $result1);
+        $this->assertEquals('<p class="text-center">Lorem ipsum dolor sit amet.</p>', $result2);
+        $this->assertEquals('<div class="row"><p>Lorem ipsum dolor sit amet.</p></div>', $result3);
+        $this->assertEquals('<div class="row"><img src="http://example.com/image1"><img src="http://example.com/image2"></div>', $result4);
     }
 
     public function testMetaOpenGraph()
     {
         $result = $this->htmlBuilder->meta(null, 'website', ['property' => 'og:type']);
 
-        $this->assertEquals('<meta content="website" property="og:type">' . PHP_EOL, $result);
+        $this->assertEquals('<meta content="website" property="og:type">', $result);
     }
 
     public function testFavicon()
@@ -102,7 +102,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $target = $this->urlGenerator->to('bar.ico');
         $result = $this->htmlBuilder->favicon('http://foo.com/bar.ico');
 
-        $this->assertEquals('<link rel="shortcut icon" type="image/x-icon" href="' . $target . '">' . PHP_EOL, $result);
+        $this->assertEquals('<link rel="shortcut icon" type="image/x-icon" href="' . $target . '">', $result);
     }
 
     public function testComponentRegistration()

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -118,8 +118,11 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
 
         $result2 = $this->htmlBuilder->link("http://www.example.com", "<span>Example.com</span>", ["class" => "example-link"], null, false);
 
+        $result3 = $this->htmlBuilder->link("https://a.com/b?id=4&not_id=5", "URL which needs escaping");
+
         $this->assertEquals('<a href="http://www.example.com" class="example-link">&lt;span&gt;Example.com&lt;/span&gt;</a>', $result1);
         $this->assertEquals('<a href="http://www.example.com" class="example-link"><span>Example.com</span></a>', $result2);
+        $this->assertEquals('<a href="https://a.com/b?id=4&amp;not_id=5">URL which needs escaping</a>', $result3);
     }
 
     public function testMailto()


### PR DESCRIPTION
When adding the FormAccessible trait to a model, the getFormValue method treats some inputs like nestedModel wrongly!
Because of it some checkboxes came unchecked.