### PR TITLE
Added Laravel 5.6 stable support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
-        "illuminate/http": "5.6.x-dev",
-        "illuminate/routing": "5.6.x-dev",
-        "illuminate/session": "5.6.x-dev",
-        "illuminate/support": "5.6.x-dev",
-        "illuminate/view": "5.6.x-dev"
+        "php": ">=7.1.3",
+        "illuminate/http": "5.6.*",
+        "illuminate/routing": "5.6.*",
+        "illuminate/session": "5.6.*",
+        "illuminate/support": "5.6.*",
+        "illuminate/view": "5.6.*"
     },
     "require-dev": {
-        "illuminate/database": "5.6.x-dev",
+        "illuminate/database": "5.6.*",
         "mockery/mockery": "~0.9.4",
         "phpunit/phpunit": "~5.4"
     },

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -527,7 +527,7 @@ class FormBuilder
         // the element. Then we'll create the final textarea elements HTML for us.
         $options = $this->html->attributes($options);
 
-        return $this->toHtmlString('<textarea' . $options . '>' . e($value). '</textarea>');
+        return $this->toHtmlString('<textarea' . $options . '>' . e($value, false). '</textarea>');
     }
 
     /**
@@ -725,7 +725,7 @@ class FormBuilder
                 $html[] = $this->option($space.$display, $value, $selected, $attributes, $optionAttributes);
             }
         }
-        return $this->toHtmlString('<optgroup label="' . e($space.$label) . '">' . implode('', $html) . '</optgroup>');
+        return $this->toHtmlString('<optgroup label="' . e($space.$label, false) . '">' . implode('', $html) . '</optgroup>');
     }
 
     /**
@@ -746,7 +746,7 @@ class FormBuilder
 
         $string = '<option' . $this->html->attributes($options) . '>';
         if ($display !== null) {
-            $string .= e($display) . '</option>';
+            $string .= e($display, false) . '</option>';
         }
 
         return $this->toHtmlString($string);
@@ -769,7 +769,7 @@ class FormBuilder
             'value' => '',
         ];
 
-        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden="hidden">' . e($display) . '</option>');
+        return $this->toHtmlString('<option' . $this->html->attributes($options) . ' hidden="hidden">' . e($display, false) . '</option>');
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -722,10 +722,10 @@ class FormBuilder
             if (is_array($display)) {
                 $html[] = $this->optionGroup($display, $value, $selected, $attributes, $optionAttributes, $level+5);
             } else {
-                $html[] = $this->option($space.$display, $value, $selected, $attributes, $optionAttributes);
+                $html[] = $this->option($space.$display, $value, $selected, $optionAttributes);
             }
         }
-        return $this->toHtmlString('<optgroup label="' . e($space.$label, false) . '">' . implode('', $html) . '</optgroup>');
+        return $this->toHtmlString('<optgroup label="' . e($space.$label, false) . '"' . $this->html->attributes($attributes) . '>' . implode('', $html) . '</optgroup>');
     }
 
     /**

--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -387,7 +387,7 @@ class HtmlBuilder
         if (is_array($value)) {
             return $this->nestedListing($key, $type, $value);
         } else {
-            return '<li>' . e($value) . '</li>';
+            return '<li>' . e($value, false) . '</li>';
         }
     }
 
@@ -456,7 +456,7 @@ class HtmlBuilder
         }
 
         if (! is_null($value)) {
-            return $key . '="' . e($value) . '"';
+            return $key . '="' . e($value, false) . '"';
         }
     }
 


### PR DESCRIPTION
Support for 5.6, tests do pass.
While checking the tests I found a bug, where the `$optGroupAttributes` wheren't added to the optgroup but where added to the child options, instead of their respective attributes. (The bug came up with the changes made in #470)

I'd like to mention that I opted out double encoding (it is now default in the `e` helper function in 5.6, so that this package works like before. If this package should, from now on, use double encoding by default I'm happy to revert the changes and fix the tests instead.