### PR TITLE
Possibility of boolean value for selected option in select field

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -787,7 +787,7 @@ class FormBuilder
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }
-        if(is_int($value) && is_bool($selected)){
+        if (is_int($value) && is_bool($selected)) {
             return (bool)$value === $selected;
         }
         return ((string) $value === (string) $selected) ? 'selected' : null;

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -572,7 +572,7 @@ class FormBuilder
      *
      * @param  string $name
      * @param  array  $list
-     * @param  string $selected
+     * @param  string|bool $selected
      * @param  array  $selectAttributes
      * @param  array  $optionsAttributes
      * @param  array  $optgroupsAttributes

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -787,7 +787,9 @@ class FormBuilder
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }
-
+        if(is_int($value) && is_bool($selected)){
+            return (bool)$value === $selected;
+        }
         return ((string) $value === (string) $selected) ? 'selected' : null;
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -464,6 +464,12 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             '<select name="countries"><option value="1" selected="selected">L</option><option value="2">M</option></select>',
             $result
         );
+
+        $select = $this->formBuilder->select('avc', [1 => 'Yes', 0 => 'No'], true, ['placeholder' => 'Select']);
+        $this->assertEquals(
+            '<select name="avc"><option value="" hidden="hidden">Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
+            $select
+        );
     }
 
     public function testSelectCollection()


### PR DESCRIPTION
Validation for this situation: selected value is a boolean in select field
Method: [FormBuilder::getSelectedValue($value, $selected)](https://github.com/AndersonFriaca/html/blob/8e96ea08a37a6db542de7234270898bdfea0045f/src/FormBuilder.php#L783)
Example:
```php
$avc = true;

{{Form::select('avc', [1 => 'Yes', 0 => 'No'], $avc, ['placeholder' => 'Select'])}}
```