### PR TITLE
Fixed bug with radio button not being checked

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -929,7 +929,7 @@ class FormBuilder
 
     /**
      * Determine if the provide value loosely compares to the value assigned to the field.
-     * Use loose comparison because Laravel model casting may be in affect and therfore
+     * Use loose comparison because Laravel model casting may be in affect and therefore
      * 1 == true and 0 == false.
      *
      * @param  string $name

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -190,7 +190,7 @@ class FormBuilder
     {
         $this->model = $model;
     }
-    
+
     /**
      * Get the current model instance on the form builder.
      *
@@ -871,7 +871,7 @@ class FormBuilder
                 return $this->getRadioCheckedState($name, $value, $checked);
 
             default:
-                return $this->getValueAttribute($name) === $value;
+                return $this->compareValues($name, $value);
         }
     }
 
@@ -924,7 +924,21 @@ class FormBuilder
             return $checked;
         }
 
-        return $this->getValueAttribute($name) === $value;
+        return $this->compareValues($name, $value);
+    }
+
+    /**
+     * Determine if the provide value loosely compares to the value assigned to the field.
+     * Use loose comparison because Laravel model casting may be in affect and therfore
+     * 1 == true and 0 == false.
+     *
+     * @param  string $name
+     * @param  string $value
+     * @return bool
+     */
+    protected function compareValues($name, $value)
+    {
+        return $this->getValueAttribute($name) == $value;
     }
 
     /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -658,6 +658,21 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<input class="span2" name="foo" type="radio" value="foobar">', $form4);
     }
 
+    public function testFormRadioWithAttributeCastToBoolean()
+    {
+        $this->setModel(['itemA' => true, 'itemB' => false]);
+
+        $radio1 = $this->formBuilder->radio('itemA', 1);
+        $radio2 = $this->formBuilder->radio('itemA', 0);
+        $radio3 = $this->formBuilder->radio('itemB', 1);
+        $radio4 = $this->formBuilder->radio('itemB', 0);
+
+        $this->assertEquals('<input checked="checked" name="itemA" type="radio" value="1">', $radio1);
+        $this->assertEquals('<input name="itemA" type="radio" value="0">', $radio2);
+        $this->assertEquals('<input name="itemB" type="radio" value="1">', $radio3);
+        $this->assertEquals('<input checked="checked" name="itemB" type="radio" value="0">', $radio4);
+    }
+
     public function testFormRadioRepopulation()
     {
         $this->formBuilder->setSessionStore($session = m::mock('Illuminate\Contracts\Session\Session'));


### PR DESCRIPTION
Fixes: https://github.com/LaravelCollective/html/issues/496

Loose comparison needs to be done because Laravel model casting may be in affect and therefore 1 == true and 0 == false.