### PR TITLE
[5.5] Fix form method of hidden input '_method' is preserved on next request

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1183,7 +1183,7 @@ class FormBuilder
         }
 
         $request = $this->request($name);
-        if (! is_null($request)) {
+        if (! is_null($request) && $name !== '_method') {
             return $request;
         }
 


### PR DESCRIPTION
_FYI: This fix was merged in the pull request https://github.com/LaravelCollective/html/pull/460
But the pull request https://github.com/LaravelCollective/html/pull/471 accidentally revert this fix_ 😕

E.G. when you submit a form with a `PATCH` method and then you submit another form which use a `DELETE` method instead, the [`FormBuilder::getValueAttribute()`](https://github.com/LaravelCollective/html/blob/v5.5.1/src/FormBuilder.php#L1135) method use the previous value of the hidden input `_method` attribute.
So the value is replaced by `PATCH` instead of the desired `DELETE` value.

Maybe related to https://github.com/LaravelCollective/html/issues/350#issuecomment-309899542

PS: I use AJAX/XHR to submit my forms.
So I don't have any HTTP redirection between my two forms submit, just DOM replacements on the Browser

