### PR TITLE
Better global configuration for considerRequest.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -123,6 +123,7 @@ class FormBuilder
         $this->view = $view;
         $this->csrfToken = $csrfToken;
         $this->request = $request;
+        $this->considerRequest = config('form.consider_request') ?: false;
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -123,7 +123,9 @@ class FormBuilder
         $this->view = $view;
         $this->csrfToken = $csrfToken;
         $this->request = $request;
-        $this->considerRequest = config('form.consider_request') ?: false;
+        if (function_exists('config')) {
+            $this->considerRequest = config('form.consider_request', false);
+        }
     }
 
     /**


### PR DESCRIPTION
Easier global configuration for previous behavior, than having to instantiate on every request in AppServiceProvider or Base Controller regardless if you're using the Form or not on that request.

Add a configuration file and store in `config/form.php`, defaults to false (new default) if it's not present.

```
return [
    'consider_request' => env('FORM_CONSIDER_REQUEST', true),
];
```