### PR TITLE
Allow sub-select to be iterable to accept array and collection

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -737,7 +737,7 @@ class FormBuilder
      */
     public function getSelectOption($display, $value, $selected, array $attributes = [], array $optgroupAttributes = [])
     {
-        if (is_array($display)) {
+        if (is_iterable($display)) {
             return $this->optionGroup($display, $value, $selected, $optgroupAttributes, $attributes);
         }
 
@@ -762,7 +762,7 @@ class FormBuilder
         $space = str_repeat("&nbsp;", $level);
         foreach ($list as $value => $display) {
             $optionAttributes = $optionsAttributes[$value] ?? [];
-            if (is_array($display)) {
+            if (is_iterable($display)) {
                 $html[] = $this->optionGroup($display, $value, $selected, $attributes, $optionAttributes, $level+5);
             } else {
                 $html[] = $this->option($space.$display, $value, $selected, $optionAttributes);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -537,6 +537,58 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
         );
         $this->assertEquals($select,
             '<select name="size"><option value="L" data-foo="bar" disabled>Large</option><option value="S">Small</option></select>');
+
+        $select = $this->formBuilder->select(
+            'size',
+            collect([
+                'Large sizes' => collect([
+                    'L' => 'Large',
+                    'XL' => 'Extra Large',
+                ]),
+                'S' => 'Small',
+            ]),
+            null,
+            [
+                'class' => 'class-name',
+                'id' => 'select-id',
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select class="class-name" id="select-id" name="size"><optgroup label="Large sizes"><option value="L">Large</option><option value="XL">Extra Large</option></optgroup><option value="S">Small</option></select>'
+        );
+
+        $select = $this->formBuilder->select(
+            'size',
+            collect([
+                'Large sizes' => collect([
+                    'L' => 'Large',
+                    'XL' => 'Extra Large',
+                ]),
+                'M' => 'Medium',
+                'Small sizes' => collect([
+                    'S' => 'Small',
+                    'XS' => 'Extra Small',
+                ]),
+            ]),
+            null,
+            [],
+            [
+                'Large sizes' => [
+                    'L' => ['disabled']
+                ],
+                'M' => ['disabled'],
+            ],
+            [
+                'Small sizes' => ['disabled'],
+            ]
+        );
+
+        $this->assertEquals(
+            $select,
+            '<select name="size"><optgroup label="Large sizes"><option value="L" disabled>Large</option><option value="XL">Extra Large</option></optgroup><option value="M" disabled>Medium</option><optgroup label="Small sizes" disabled><option value="S">Small</option><option value="XS">Extra Small</option></optgroup></select>'
+        );
     }
 
     public function testFormSelectRepopulation()


### PR DESCRIPTION
I think this simple solution should solve the issue #535 and unify the behavior between select and sub-select and accept array and collection as well.