### PR TITLE
Always check the value is string (fix #464)

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1164,7 +1164,7 @@ class FormBuilder
 
         $old = $this->old($name);
 
-        if (! is_null($old) && $name !== '_method') {
+        if (! is_null($old) && is_string($old) && $name !== '_method') {
             return $old;
         }
 
@@ -1183,7 +1183,7 @@ class FormBuilder
         }
 
         $request = $this->request($name);
-        if (! is_null($request) && $name !== '_method') {
+        if (! is_null($request) && is_string($request) && $name !== '_method') {
             return $request;
         }
 


### PR DESCRIPTION
Always check the value is string (fix #464)

This PR adds `is_string()` to check if value is string or not
To fix `htmlentities() expects parameter 1 to be string, array given`