### PR TITLE
Adding additional check to input() function's argument 

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -285,6 +285,9 @@ class FormBuilder
     public function input($type, $name, $value = null, $options = [])
     {
         $this->type = $type;
+        if (!is_array($options)){
+            $options = json_decode($options);   
+        }
 
         if (! isset($options['name'])) {
             $options['name'] = $name;


### PR DESCRIPTION
In the function `input($type, $name, $value = null, $options = [])`, the `$options` argument might not always be sent as an array. It could be sent as a JSON string. So, we just add an additional check and convert the json string to array.
