### PR TITLE
Disables select's placeholder so it can't be used

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -809,6 +809,7 @@ class FormBuilder
 
         $options = [
             'selected' => $selected,
+            'disabled' => true,
             'value' => '',
         ];
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -521,7 +521,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
 
         $select = $this->formBuilder->select('avc', [1 => 'Yes', 0 => 'No'], true, ['placeholder' => 'Select']);
         $this->assertEquals(
-            '<select name="avc"><option value="">Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
+            '<select name="avc"><option disabled value="">Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
             $select
         );
     }
@@ -622,7 +622,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" disabled value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',


### PR DESCRIPTION
On text fields, placeholders only hold the place of the future value to be written, so they aren't really a value. 

However, the current placeholder for select boxes is selectable as a value. If the select box is to include an empty value, that should be present on the options list instead of being included via a placeholder.

Setting an option as selected+disabled still shows it as selected when there's no other selection (functioning as a placeholder), while disallows the user to select it once something else was chosen (prohibiting a smart user to set it as an empty option).

![selection_044](https://user-images.githubusercontent.com/532299/43306491-c03a8094-9151-11e8-8f11-0b97545b8ab1.png)