### PR TITLE
Make select placeholder's none selectable

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -810,6 +810,8 @@ class FormBuilder
         $options = [
             'selected' => $selected,
             'value' => '',
+            'disabled' => true,
+            'hidden' => true,
         ];
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display, false) . '</option>');

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -811,7 +811,7 @@ class FormBuilder
             'selected' => $selected,
             'value' => '',
             'disabled' => true,
-            'hidden' => true,
+            // 'hidden' => true,
         ];
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display, false) . '</option>');

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -631,7 +631,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option value="">Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option value="" disabled hidden>Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
             'encoded_html',
@@ -640,7 +640,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
             ['placeholder' => 'Select the &nbsp;']
         );
         $this->assertEquals($select,
-            '<select name="encoded_html"><option selected="selected" value="">Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
+            '<select name="encoded_html"><option selected="selected" value="" disabled hidden>Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
         );
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -521,7 +521,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
 
         $select = $this->formBuilder->select('avc', [1 => 'Yes', 0 => 'No'], true, ['placeholder' => 'Select']);
         $this->assertEquals(
-            '<select name="avc"><option value="" disabled hidden>Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
+            '<select name="avc"><option value="" disabled>Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
             $select
         );
     }
@@ -622,7 +622,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" value="" disabled hidden>Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" value="" disabled>Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',
@@ -631,7 +631,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option value="" disabled hidden>Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option value="" disabled>Select One...</option><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
             'encoded_html',
@@ -640,7 +640,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
             ['placeholder' => 'Select the &nbsp;']
         );
         $this->assertEquals($select,
-            '<select name="encoded_html"><option selected="selected" value="" disabled hidden>Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
+            '<select name="encoded_html"><option selected="selected" value="" disabled>Select the &nbsp;</option><option value="no_break_space">&nbsp;</option><option value="ampersand">&amp;</option><option value="lower_than">&lt;</option></select>'
         );
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -521,7 +521,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
 
         $select = $this->formBuilder->select('avc', [1 => 'Yes', 0 => 'No'], true, ['placeholder' => 'Select']);
         $this->assertEquals(
-            '<select name="avc"><option value="">Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
+            '<select name="avc"><option value="" disabled hidden>Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
             $select
         );
     }
@@ -622,7 +622,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
           ['placeholder' => 'Select One...']
         );
         $this->assertEquals($select,
-          '<select name="size"><option selected="selected" value="">Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
+          '<select name="size"><option selected="selected" value="" disabled hidden>Select One...</option><option value="L">Large</option><option value="S">Small</option></select>');
 
         $select = $this->formBuilder->select(
           'size',


### PR DESCRIPTION
Also hide it from the open dropdown list (that's a neat trick aye).

This change means the close select shows the default placeholder text, but when opened, the placeholder is not present to be selected.

...

hmm just thinking about it, this could break BC if people are relying on the placeholder being selectable?
Maybe both these setting need to be behind a setting?

What are your thoughts on this?