### PR TITLE
Simplify `hasFormMutator` method

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -2,19 +2,10 @@
 
 namespace Collective\Html\Eloquent;
 
-use ReflectionClass;
-use ReflectionMethod;
 use Illuminate\Support\Str;
 
 trait FormAccessible
 {
-
-    /**
-     * A cached ReflectionClass instance for $this
-     *
-     * @var ReflectionClass
-     */
-    protected $reflection;
 
     /**
      * @param string $key
@@ -83,14 +74,7 @@ trait FormAccessible
      */
     public function hasFormMutator($key)
     {
-        $methods = $this->getReflection()->getMethods(ReflectionMethod::IS_PUBLIC);
-
-        $mutator = collect($methods)
-          ->first(function (ReflectionMethod $method) use ($key) {
-              return $method->getName() === 'form' . Str::studly($key) . 'Attribute';
-          });
-
-        return (bool) $mutator;
+        return method_exists($this, 'form' . Str::studly($key) . 'Attribute');
     }
 
     /**
@@ -102,18 +86,5 @@ trait FormAccessible
     private function mutateFormAttribute($key, $value)
     {
         return $this->{'form' . Str::studly($key) . 'Attribute'}($value);
-    }
-
-    /**
-     * Get a ReflectionClass Instance
-     * @return ReflectionClass
-     */
-    protected function getReflection()
-    {
-        if (! $this->reflection) {
-            $this->reflection = new ReflectionClass($this);
-        }
-
-        return $this->reflection;
     }
 }


### PR DESCRIPTION
The previous implementation that relied on Reflection is causing fatal PHP errors, when a Model which uses the FormAccessible trait is being dumped (with Symfony's dumper).

The reason is because the dumper is using reflection to dump all the model's properties, and when it hits the `reflection` property, it tries to cast the `ReflectionClass` using `ReflectionClass`, which causes an `Internal error: Failed to retrieve the reflection object`.

The new implementation uses the same stragegy as Eloquent's `hasGetMutator`, which calls `method_exists`.

This is more efficient as we don't need a whole reflection object, neither we need to iterate through all the reflected public properties of the model, just to find the first one that matches the mutator method name.