### PR TITLE
[5.7] Allow form mutators to pick up on array

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -37,8 +37,9 @@ trait FormAccessible
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.
-        if ($this->hasFormMutator($key)) {
-            return $this->mutateFormAttribute($key, $value);
+        $mutatorKey = strtok($key, '.');
+        if ($this->hasFormMutator($mutatorKey)) {
+            return $this->mutateFormAttribute($mutatorKey, $value);
         }
 
         $keys = explode('.', $key);

--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -52,6 +52,15 @@ class FormAccessibleTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($user, $model->getFormValue('user'));
         $this->assertEquals('Get name: Anton', $model->getFormValue('user')->name);
         $this->assertEquals('Get name for form: Anton', $model->getFormValue('user.name'));
+
+        $custom_array = [
+            1 => 10,
+            2 => 20,
+            3 => 30,
+        ];
+        $this->assertEquals($custom_array, $model->getFormValue('custom_array.1'));
+        $this->assertEquals($custom_array, $model->getFormValue('custom_array.2'));
+        $this->assertEquals($custom_array, $model->getFormValue('custom_array.3'));
     }
 
     public function testItCanMutateRelatedValuesForForms()
@@ -138,6 +147,15 @@ class ModelThatUsesForms extends Model
     public function formCreatedAtAttribute(Carbon $value)
     {
         return $value->timestamp;
+    }
+
+    public function formCustomArrayAttribute()
+    {
+        return [
+            1 => 10,
+            2 => 20,
+            3 => 30,
+        ];
     }
 
     public function getCreatedAtAttribute($value)


### PR DESCRIPTION
Before this PR having select tags (or any other tag) with name attribute like this `questions[3]` `questions[5]` and a form mutator like this on the model

```php
class Paper extends Model
{
    #This is only a representation of what the mutator returns, in real code i have a call to the question relation
    public function formQuestionsAttribute()
    {
    	return [
    		3 => 15,
    		5 => 16
    	];
    }
}
```

Will not pick up the values from the mutator because it is looking for a mutator named like these

`formQuestions.3Attribute` and `formQuestions.5Attribute` instead of a mutator named like in the example above `formQuestionsAttribute`

It's known to everyone it is not possible to have php method names with dots in it.
Also, it's not possible to actually have mutators for each question because the questions are dynamic (I have a Question model)

So what this PR does is that it actually takes the first portion of the `$key` variable that exists before the a dot and use that to find a mutator method

the `formQuestions.3Attribute` will become `formQuestionsAttribute`

Also there is no breaking changes introduced here for two reasons 

1- It's not possible that someone did have mutators that contains a dot in the method name because php does not allow dots in method names.

2- This does not affect the relationship logic, because we are only looking for methods that follow the package mutator naming convention `formXXXXXAttribute`
