### PR TITLE
Add the ability to disable the csrf_field input injection

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1267,6 +1267,12 @@ class FormBuilder
             $appendage .= $this->token();
         }
 
+        // If we create more than one form on the same page, the injectCsrfToken property
+        // will remain the same across every forms since the form builder is resolved once.
+        // In order to ensure the next form will start with a csrf_token by default, we
+        // need to set it to true.
+        $this->injectCsrfToken = true;
+
         return $appendage;
     }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -148,7 +148,7 @@ class FormBuilder
         // If the method is PUT, PATCH or DELETE we will need to add a spoofer hidden
         // field that will instruct the Symfony request to pretend the method is a
         // different method than it actually is, for convenience from the forms.
-        $append = $this->getAppendage($method);
+        $append = $this->getAppendage($method, $options['csrf_token'] ?? true);
 
         if (isset($options['files']) && $options['files']) {
             $options['enctype'] = 'multipart/form-data';
@@ -1227,10 +1227,11 @@ class FormBuilder
      * Get the form appendage for the given method.
      *
      * @param  string $method
+     * @param bool $with_csrf_token
      *
      * @return string
      */
-    protected function getAppendage($method)
+    protected function getAppendage($method, $with_csrf_token)
     {
         list($method, $appendage) = [strtoupper($method), ''];
 
@@ -1241,10 +1242,9 @@ class FormBuilder
             $appendage .= $this->hidden('_method', $method);
         }
 
-        // If the method is something other than GET we will go ahead and attach the
-        // CSRF token to the form, as this can't hurt and is convenient to simply
-        // always have available on every form the developers creates for them.
-        if ($method !== 'GET') {
+        // If the method is something other than GET and $with_csrf_token is true,
+        // we will attach the CSRF token to the form.
+        if ($method !== 'GET' && $with_csrf_token) {
             $appendage .= $this->token();
         }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -243,13 +243,12 @@ class FormBuilder
 
     /**
      * Enable or disable automatic csrf_token injection
-     * @param bool $inject
      *
      * @return self
      */
-    public function injectCsrfToken($inject = true)
+    public function withoutCsrf()
     {
-        $this->injectCsrfToken = $inject;
+        $this->injectCsrfToken = false;
 
         return $this;
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -50,6 +50,13 @@ class FormBuilder
     protected $csrfToken;
 
     /**
+     * Inject the csrf_token hidden input automatically
+     *
+     * @var bool
+     */
+    protected $injectCsrfToken = true;
+
+    /**
      * Consider Request variables while auto fill.
      * @var bool
      */
@@ -148,7 +155,7 @@ class FormBuilder
         // If the method is PUT, PATCH or DELETE we will need to add a spoofer hidden
         // field that will instruct the Symfony request to pretend the method is a
         // different method than it actually is, for convenience from the forms.
-        $append = $this->getAppendage($method, $options['csrf_token'] ?? true);
+        $append = $this->getAppendage($method);
 
         if (isset($options['files']) && $options['files']) {
             $options['enctype'] = 'multipart/form-data';
@@ -232,6 +239,19 @@ class FormBuilder
         $token = ! empty($this->csrfToken) ? $this->csrfToken : $this->session->token();
 
         return $this->hidden('_token', $token);
+    }
+
+    /**
+     * Enable or disable automatic csrf_token injection
+     * @param bool $inject
+     *
+     * @return self
+     */
+    public function injectCsrfToken($inject = true)
+    {
+        $this->injectCsrfToken = $inject;
+
+        return $this;
     }
 
     /**
@@ -1227,11 +1247,10 @@ class FormBuilder
      * Get the form appendage for the given method.
      *
      * @param  string $method
-     * @param bool $with_csrf_token
      *
      * @return string
      */
-    protected function getAppendage($method, $with_csrf_token)
+    protected function getAppendage($method)
     {
         list($method, $appendage) = [strtoupper($method), ''];
 
@@ -1242,9 +1261,9 @@ class FormBuilder
             $appendage .= $this->hidden('_method', $method);
         }
 
-        // If the method is something other than GET and $with_csrf_token is true,
+        // If the method is something other than GET and $injectCsrfToken property is true,
         // we will attach the CSRF token to the form.
-        if ($method !== 'GET' && $with_csrf_token) {
+        if ($method !== 'GET' && $this->injectCsrfToken) {
             $appendage .= $this->token();
         }
 


### PR DESCRIPTION
Hello !

This is a simple addition to allow the user to disable the csrf_token input auto injection. It can be useful when you need to send a form with a specific set of inputs (as mentionned here https://github.com/LaravelCollective/html/issues/362).

With this PR, you can now use the injectCsrfToken() method to enable or disable automatic injection.

`Form::injectCsrfToken(false)->open()` will open a form **without** csrf_token
`Form::injectCsrfToken(true)->open()` or simply `Form::open()`will open a form **with** csrf_token
