### PR TITLE
Wrong return doc comment in renderComponent function

### DIFF
--- a/src/Componentable.php
+++ b/src/Componentable.php
@@ -48,7 +48,7 @@ trait Componentable
      * @param        $name
      * @param  array $arguments
      *
-     * @return \Illuminate\Contracts\View\View
+     * @return HtmlString
      */
     protected function renderComponent($name, array $arguments)
     {


### PR DESCRIPTION
renderComponent return a HTMLString (Illuminate\Support\HtmlString)