### PR TITLE
respect HtmlString when html encoding

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -50,7 +50,7 @@ class HtmlBuilder
      */
     public function entities($value)
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+        return e($value, false);
     }
 
     /**
@@ -62,7 +62,7 @@ class HtmlBuilder
      */
     public function decode($value)
     {
-        return html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+        return e($value, true);
     }
 
     /**


### PR DESCRIPTION
Laravel's `HtmlString` should always be respected. Always use `e()`.

PR against 5.8, but should also apply to 5.7 and 5.6 etc.