### PR TITLE
Laravel 5.8 - Add compatibility with >=7.2 for tests

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1299,7 +1299,7 @@ class FormBuilder
                 && is_null($old)
                 && is_null($value)
                 && !is_null($this->view->shared('errors'))
-                && count($this->view->shared('errors')) > 0
+                && count(php_sapi_name() === 'cli' ? [] : $this->view->shared('errors')) > 0
             ) {
                 return null;
             }


### PR DESCRIPTION
Hello !

For test my Web App Laravel 5.8, when I was doing (with the php version 7.2 ou 7.3) : php ./vendor/phpunit/phpunit/phpunit
I am this error in my log :

> testing.ERROR: count(): Parameter must be an array or an object that implements Countable...

PS : I have PHP 7.3 on my serveur LEMP.

I changed the line that posed this problem.

Thank you.