### PR TITLE
Laravel 6.0 - Add compatibility with >=7.2 for tests

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1298,7 +1298,7 @@ class FormBuilder
                 && is_null($old)
                 && is_null($value)
                 && !is_null($this->view->shared('errors'))
-                && count($this->view->shared('errors')) > 0
+                && count(php_sapi_name() === 'cli' ? [] : $this->view->shared('errors')) > 0
             ) {
                 return null;
             }


### PR DESCRIPTION
Hello !

For test my Web App Laravel 6.0, when I was doing (with the php version 7.2 ou 7.3) : php ./vendor/phpunit/phpunit/phpunit
I am this error in my log :

testing.ERROR: count(): Parameter must be an array or an object that implements Countable...

I changed the line that posed this problem.

Thank you to merger it.