### PR TITLE
Check if errors are countable instead of checking the SAPI name

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1299,7 +1299,7 @@ class FormBuilder
                 && is_null($old)
                 && is_null($value)
                 && !is_null($this->view->shared('errors'))
-                && count(php_sapi_name() === 'cli' ? [] : $this->view->shared('errors')) > 0
+                && count(is_countable($this->view->shared('errors')) ? $this->view->shared('errors') : []) > 0
             ) {
                 return null;
             }


### PR DESCRIPTION
The 6.0 branch was updated to check if the error bag was countable instead of checking the SAPI name in 2f181aba73390eec13d398bf57877b1cc3bc2588 but the 5.8 branch was not.

This PR makes the same change to the 5.8 branch.