### PR TITLE
Update constraints to match Laravel 6 releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/http": "6.0.*",
-        "illuminate/routing": "6.0.*",
-        "illuminate/session": "6.0.*",
-        "illuminate/support": "6.0.*",
-        "illuminate/view": "6.0.*"
+        "illuminate/http": "^6.0",
+        "illuminate/routing": "^6.0",
+        "illuminate/session": "^6.0",
+        "illuminate/support": "^6.0",
+        "illuminate/view": "^6.0"
     },
     "require-dev": {
-        "illuminate/database": "6.0.*",
+        "illuminate/database": "^6.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~7.1"
     },


### PR DESCRIPTION
Necessary to resolve the incompatibility now that Laravel 6.1 was tagged.