### PR TITLE
Url param in HtmlBuilder constructor shouldn't have null by default

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -35,7 +35,7 @@ class HtmlBuilder
      * @param \Illuminate\Contracts\Routing\UrlGenerator $url
      * @param \Illuminate\Contracts\View\Factory         $view
      */
-    public function __construct(UrlGenerator $url = null, Factory $view)
+    public function __construct(UrlGenerator $url, Factory $view)
     {
         $this->url = $url;
         $this->view = $view;


### PR DESCRIPTION
There is no need of having null value by default in constructor for two reasons. 
Firstly, when this class is being registered in ServiceProvider - `$app['url']` already has UrlGenerator inside Laravel's container.
```
$this->app->singleton('html', function ($app) {
    return new HtmlBuilder($app['url'], $app['view']);
});
```
Secondly, even if hypothetically we give `null` as a first argument to HtmlBuilder's constructor - then the class will raise an Exception. Because inside of the class `$url` is used directly without any check for null value, like: `$this->url->asset($url, $secure);`;