### PR TITLE
Fixes a bug where passed to route() causes errors

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1201,7 +1201,7 @@ class FormBuilder
     protected function getRouteAction($options)
     {
         if (is_array($options)) {
-            return $this->url->route($options[0], array_slice($options, 1));
+            return $this->url->route($options[0], head(array_slice($options, 1)));
         }
 
         return $this->url->route($options);


### PR DESCRIPTION
This attempts to fix a bug with routes having an array with two values.

This bugfix was tested and works with the following.

Non-route model binding:
```
{{ Form::open(['route' => ['mytest', [$file->id]]]) }}
```

Another non-route model binding:
```
{{ Form::open(['route' => ['mytest', $file->id]]) }}
```

Multiple models into route model binding:
```
{{ Form::open(['route' => ['manage.files.delete', [$currentPodcast, $file]]]) }}
```

Single model into route model binding:
```
{{ Form::open(['route' => ['manage.podcast.delete', $currentPodcast]]) }}
```