### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "illuminate/http": "^6.0",
-        "illuminate/routing": "^6.0",
-        "illuminate/session": "^6.0",
-        "illuminate/support": "^6.0",
-        "illuminate/view": "^6.0"
+        "php": ">=7.2.5",
+        "illuminate/http": "^6.0|^7.0",
+        "illuminate/routing": "^6.0|^7.0",
+        "illuminate/session": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
+        "illuminate/view": "^6.0|^7.0"
     },
     "require-dev": {
-        "illuminate/database": "^6.0",
+        "illuminate/database": "^6.0|^7.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~7.1"
     },


### PR DESCRIPTION
This adds support for Laravel 6 _or_ 7, as well as increases the PHP requirement to be minimally compatible with both versions.