### PR TITLE
fix textarea value escaping

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -570,7 +570,7 @@ class FormBuilder
         // the element. Then we'll create the final textarea elements HTML for us.
         $options = $this->html->attributes($options);
 
-        return $this->toHtmlString('<textarea' . $options . '>' . e($value, false). '</textarea>');
+        return $this->toHtmlString('<textarea' . $options . '>' . e($value). '</textarea>');
     }
 
     /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -387,7 +387,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('<textarea class="span2" name="foo" cols="50" rows="10"></textarea>', $form3);
         $this->assertEquals('<textarea name="foo" cols="60" rows="15"></textarea>', $form4);
         $this->assertEquals('<textarea name="encoded_html" cols="60" rows="50">Eggs &amp; Sausage</textarea>', $form5);
-        $this->assertEquals('<textarea name="encoded_html" cols="60" rows="50">Eggs &amp;&amp; Sausage</textarea>', $form6);
+        $this->assertEquals('<textarea name="encoded_html" cols="60" rows="50">Eggs &amp;amp;&amp;amp; Sausage</textarea>', $form6);
     }
 
     public function testSelect()


### PR DESCRIPTION
The web page should show exactly the value passed to the `textarea` function.
`Form::textarea('foo', 'units volt&watt&amp;')` should show `units volt&watt&amp;` instead of `units volt&watt&` in the textarea.