### PR TITLE
Fix method_exists when model is not string or object (PHP8)

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1362,7 +1362,7 @@ class FormBuilder
     {
         $key = $this->transformKey($name);
 
-        if (method_exists($this->model, 'getFormValue')) {
+        if ((is_string($this->model) || is_object($this->model)) && method_exists($this->model, 'getFormValue')) {
             return $this->model->getFormValue($key);
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/516807/99625898-0eff3780-2a96-11eb-9e37-b80f25ad0e1f.png)

> method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given

PHP: 8.0.0-dev (RC4)

Happens when I used `Form::checkbox()` without calling `Form::model()` first. But you might not always need `Form::model()`. I added `is_string($this->model) || is_object($this->model)` in that if statement, so it doesn't crash.