### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/FormAccessibleTest.php
+++ b/tests/FormAccessibleTest.php
@@ -14,7 +14,7 @@ use Mockery as m;
 
 class FormAccessibleTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Capsule::table('models')->truncate();
         Model::unguard();

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -22,7 +22,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
     /**
      * Setup the test environment.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->urlGenerator = new UrlGenerator(new RouteCollection(), Request::create('/foo', 'GET'));
         $this->viewFactory = m::mock(Factory::class);
@@ -46,7 +46,7 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
     /**
      * Destroy the test environment.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -13,14 +13,14 @@ class HtmlBuilderTest extends PHPUnit\Framework\TestCase
     /**
      * Setup the test environment.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->urlGenerator = new UrlGenerator(new RouteCollection(), Request::create('/foo', 'GET'));
         $this->viewFactory = m::mock(Factory::class);
         $this->htmlBuilder = new HtmlBuilder($this->urlGenerator, $this->viewFactory);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html?highlight=fixtures), it should be the `protected function setUp(): void` and `protected function tearDown(): void`.