### PR TITLE
Fix meta function argument phpdoc

### DIFF
--- a/src/HtmlBuilder.php
+++ b/src/HtmlBuilder.php
@@ -442,7 +442,7 @@ class HtmlBuilder
      * Build a single attribute element.
      *
      * @param string $key
-     * @param string $value
+     * @param string|bool|array|null $value
      *
      * @return string
      */
@@ -510,7 +510,7 @@ class HtmlBuilder
     /**
      * Generate a meta tag.
      *
-     * @param string $name
+     * @param string|null $name
      * @param string $content
      * @param array  $attributes
      *


### PR DESCRIPTION
Currently `Html::meta()` only accepts string `$name` in phpdoc, but it can be `null` as well. For open graph name is not required attribute.

Usage sample: `Html::meta(null, 'This is description', ['property' => 'og:description'])`

This will fix phpstan & ide errors/warnings when using `null`.

Also I updated `attributeElement` phpdoc types for arguments, since it's used by meta function.