### PR TITLE
Pre-process date values

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -431,7 +431,9 @@ class FormBuilder
      */
     public function date($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
+        $value ??= $this->getValueAttribute($name, $value);
+
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('Y-m-d');
         }
 


### PR DESCRIPTION
Given that a form is opened with Form::model
When using Form::date to create a date field and leaving the value null to fetch the value from the model, when the value is a Carbon then the value is not formatted, and is instead set as Y-m-d H:i:s causing the date to not be selected correctly. If you pass a carbon directly to the value (instead of null) then it is correctly formatted to Y-m-d.

This pull request pre-processes the value when it's null using getValueAttribute. Additionally, it replaces DateTime with DateTimeInterface to allow the use of CarbonImmutable etc