### PR TITLE
Fix incorrect doc types

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -673,8 +673,8 @@ class FormBuilder
      * Create a select range field.
      *
      * @param  string $name
-     * @param  string $begin
-     * @param  string $end
+     * @param  int    $begin
+     * @param  int    $end
      * @param  string $selected
      * @param  array  $options
      *


### PR DESCRIPTION
These arguments are passed into the PHP range() function, and it looks like integers are usually expected.

If the expected type is really ``string`` then there need to be some other checks as ``range($s1, $s2)`` is unlikely to do what is expected.