### PR TITLE
Fix the placeholder in the select form to prevent it from being selected

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -810,6 +810,7 @@ class FormBuilder
         $options = [
             'selected' => $selected,
             'value' => '',
+            'hidden' => 'true'
         ];
 
         return $this->toHtmlString('<option' . $this->html->attributes($options) . '>' . e($display, false) . '</option>');


### PR DESCRIPTION
Hello, I found the attribute of placholder in select form fascinating, but sometimes I clicked on it as an option, and, becuase of it is a placeholder, it muest not be clickeable. This probles is fixed easily in html, adding the attribute hidden yo the placeholder option. So I did it in the source code, adn I wanted to share it with you to be applied in the repository