### PR TITLE
fix: ensure Form::date supports Carbon by checking DateTimeInterface

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -431,7 +431,7 @@ class FormBuilder
      */
     public function date($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
+       if ($value instanceof \DateTimeInterface) { //By changing the type check to DateTimeInterface, you ensure that the form field can accept both DateTime and Carbon instances.
             $value = $value->format('Y-m-d');
         }
 
@@ -467,7 +467,7 @@ class FormBuilder
      */
     public function datetimeLocal($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             $value = $value->format('Y-m-d\TH:i');
         }
 
@@ -517,7 +517,7 @@ class FormBuilder
      */
     public function week($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             $value = $value->format('Y-\WW');
         }
 
@@ -1036,7 +1036,7 @@ class FormBuilder
      */
     public function month($name, $value = null, $options = [])
     {
-        if ($value instanceof DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             $value = $value->format('Y-m');
         }
 


### PR DESCRIPTION
what is this pr about?
Form date field doesn't support CarbonImmutable #703


Updated the date validation in Form::date to check if the value implements DateTimeInterface instead of just checking for DateTime instances. This allows compatibility with both DateTime and Carbon objects.